### PR TITLE
Add support for arena mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ many needed fixes and additional gameplay elements.
     - Buybacks
     - Revive Markers
     - ...and much more
-- Compatible with any map that has a resupply locker
+- Compatible with arena mode and any map with resupply lockers
 - Configurable using plugin ConVars
 
 ## Requirements

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -505,6 +505,12 @@ public int MenuHandler_UpgradeRespec(Menu menu, MenuAction action, int param1, i
 			{
 				if (strcmp(info, "respec") == 0)
 				{
+					if (IsInArenaMode())
+					{
+						MvMPlayer(param1).IsSwitchingClass = true;
+						SetEntProp(param1, Prop_Send, "m_bInUpgradeZone", false);
+					}
+					
 					MvMPlayer(param1).RemoveAllUpgrades();
 					
 					int populator = FindEntityByClassname(MaxClients + 1, "info_populator");

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -109,8 +109,6 @@ public void OnPluginStart()
 	
 	HookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);
 	
-	AddCommandListener(CommandListener_JoinClass, "joinclass");
-	
 	AddNormalSoundHook(NormalSoundHook);
 	
 	g_HudSync = CreateHudSynchronizer();
@@ -438,11 +436,6 @@ public Action EntityOutput_OnTimer10SecRemain(const char[] output, int caller, i
 			EmitGameSoundToAll("music.mvm_start_mid_wave");
 		}
 	}
-}
-
-public Action CommandListener_JoinClass(int client, const char[] command, int argc)
-{
-	EmitGameSoundToClient(client, "music.mvm_class_select");
 }
 
 public Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &entity, int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -203,12 +203,14 @@ public void OnMapStart()
 		//Arena maps usually don't have resupply lockers, create a dummy upgrade station to initialize the upgrade system
 		DispatchSpawn(CreateEntityByName("func_upgradestation"));
 	}
-	
-	//Create upgrade stations (preserved entity)
-	int regenerate = MaxClients + 1;
-	while ((regenerate = FindEntityByClassname(regenerate, "func_regenerate")) != -1)
+	else
 	{
-		CreateUpgradeStation(regenerate);
+		//Create upgrade stations (preserved entity)
+		int regenerate = MaxClients + 1;
+		while ((regenerate = FindEntityByClassname(regenerate, "func_regenerate")) != -1)
+		{
+			CreateUpgradeStation(regenerate);
+		}
 	}
 }
 

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -516,16 +516,6 @@ public int MenuHandler_UpgradeRespec(Menu menu, MenuAction action, int param1, i
 			{
 				if (strcmp(info, "respec") == 0)
 				{
-					if (IsInArenaMode())
-					{
-						if (GetEntProp(param1, Prop_Send, "m_bInUpgradeZone"))
-						{
-							MvMPlayer(param1).IsClosingUpgradeMenu = true;
-						}
-						
-						SetEntProp(param1, Prop_Send, "m_bInUpgradeZone", false);
-					}
-					
 					MvMPlayer(param1).RemoveAllUpgrades();
 					
 					int populator = FindEntityByClassname(MaxClients + 1, "info_populator");
@@ -535,6 +525,16 @@ public int MenuHandler_UpgradeRespec(Menu menu, MenuAction action, int param1, i
 						int totalAcquiredCurrency = MvMTeam(TF2_GetClientTeam(param1)).AcquiredCredits + mvm_currency_starting.IntValue;
 						int spentCurrency = SDKCall_GetPlayerCurrencySpent(populator, param1);
 						MvMPlayer(param1).Currency = totalAcquiredCurrency - spentCurrency;
+					}
+					
+					if (IsInArenaMode())
+					{
+						if (GetEntProp(param1, Prop_Send, "m_bInUpgradeZone"))
+						{
+							MvMPlayer(param1).IsClosingUpgradeMenu = true;
+						}
+						
+						SetEntProp(param1, Prop_Send, "m_bInUpgradeZone", false);
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -339,9 +339,9 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				if (IsInArenaMode())
 				{
 					//If the player is switching classes, reopen their menu as soon as the previous one closes
-					if (MvMPlayer(client).IsSwitchingClass)
+					if (MvMPlayer(client).IsClosingUpgradeMenu)
 					{
-						MvMPlayer(client).IsSwitchingClass = false;
+						MvMPlayer(client).IsClosingUpgradeMenu = false;
 						
 						//Prevent edge case where the upgrade menu stays open when switching classes right before round start
 						if (GameRules_GetRoundState() == RoundState_Preround)
@@ -509,7 +509,7 @@ public int MenuHandler_UpgradeRespec(Menu menu, MenuAction action, int param1, i
 				{
 					if (IsInArenaMode())
 					{
-						MvMPlayer(param1).IsSwitchingClass = true;
+						MvMPlayer(param1).IsClosingUpgradeMenu = true;
 						SetEntProp(param1, Prop_Send, "m_bInUpgradeZone", false);
 					}
 					

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -336,7 +336,21 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				
 				if (IsInArenaMode())
 				{
-					SetEntProp(client, Prop_Send, "m_bInUpgradeZone", false);
+					//If the player is switching classes, reopen their menu as soon as the previous one closes
+					if (MvMPlayer(client).IsSwitchingClass)
+					{
+						MvMPlayer(client).IsSwitchingClass = false;
+						
+						//Prevent edge case where the upgrade menu stays open when switching classes right before round start
+						if (GameRules_GetRoundState() == RoundState_Preround)
+						{
+							SetEntProp(client, Prop_Send, "m_bInUpgradeZone", true);
+						}
+					}
+					else
+					{
+						SetEntProp(client, Prop_Send, "m_bInUpgradeZone", false);
+					}
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -28,6 +28,7 @@
 
 #define PLUGIN_VERSION	"1.0.0"
 
+#define TF_GAMETYPE_ARENA		4
 #define MEDIGUN_CHARGE_INVULN	0
 #define LOADOUT_POSITION_ACTION	9
 
@@ -197,6 +198,12 @@ public void OnMapStart()
 	//An info_populator entity is required for a lot of MvM-related stuff (preserved entity)
 	CreateEntityByName("info_populator");
 	
+	if (IsInArenaMode())
+	{
+		//Arena maps usually don't have resupply lockers, create a dummy upgrade station to initialize the upgrade system
+		DispatchSpawn(CreateEntityByName("func_upgradestation"));
+	}
+	
 	//Create upgrade stations (preserved entity)
 	int regenerate = MaxClients + 1;
 	while ((regenerate = FindEntityByClassname(regenerate, "func_regenerate")) != -1)
@@ -326,6 +333,11 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				AcceptEntityInput(client, "AddContext");
 				
 				CancelClientMenu(client);
+				
+				if (IsInArenaMode())
+				{
+					SetEntProp(client, Prop_Send, "m_bInUpgradeZone", false);
+				}
 			}
 		}
 		else if (strcmp(section, "+use_action_slot_item_server") == 0)

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -343,7 +343,11 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				
 				if (IsInArenaMode())
 				{
-					//If the player is switching classes, reopen their menu as soon as the previous one closes
+					//NOTE: This is here because the upgrade menu takes a while to fully close clientside.
+					//Attempting to reopen it while it is still closing will lead to it staying open with the old layout.
+					//As a workaround, we check for MvM_UpgradesDone to detect whether the menu has fully closed clientside.
+					
+					//We were waiting for this player's menu to close, reopen it right away
 					if (MvMPlayer(client).IsClosingUpgradeMenu)
 					{
 						MvMPlayer(client).IsClosingUpgradeMenu = false;

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -224,6 +224,11 @@ public void OnClientPutInServer(int client)
 	SDKHooks_HookClient(client);
 }
 
+public void OnClientDisconnect(int client)
+{
+	MvMPlayer(client).Reset();
+}
+
 public void TF2_OnWaitingForPlayersEnd()
 {
 	g_ForceMapReset = true;
@@ -509,7 +514,11 @@ public int MenuHandler_UpgradeRespec(Menu menu, MenuAction action, int param1, i
 				{
 					if (IsInArenaMode())
 					{
-						MvMPlayer(param1).IsClosingUpgradeMenu = true;
+						if (GetEntProp(param1, Prop_Send, "m_bInUpgradeZone"))
+						{
+							MvMPlayer(param1).IsClosingUpgradeMenu = true;
+						}
+						
 						SetEntProp(param1, Prop_Send, "m_bInUpgradeZone", false);
 					}
 					

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -26,7 +26,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.0.0"
+#define PLUGIN_VERSION	"1.1.0"
 
 #define TF_GAMETYPE_ARENA		4
 #define MEDIGUN_CHARGE_INVULN	0

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -516,7 +516,7 @@ public MRESReturn DHookCallback_RoundRespawn_Pre()
 	{
 		if (g_ForceMapReset)
 		{
-			g_ForceMapReset = !g_ForceMapReset;
+			g_ForceMapReset = false;
 			
 			//Reset accumulated team credits on a full reset
 			MvMTeam(TFTeam_Red).AcquiredCredits = 0;

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -228,7 +228,10 @@ public void Event_PlayerChangeClass(Event event, const char[] name, bool dontBro
 		//To work around this issue, we wait for the menu to be fully closed before reopening it by listening to
 		//the MvM_UpgradesDone KeyValues client command (see: OnClientCommandKeyValues).
 		
-		MvMPlayer(client).IsSwitchingClass = view_as<bool>(GetEntProp(client, Prop_Send, "m_bInUpgradeZone"));
+		if (GetEntProp(client, Prop_Send, "m_bInUpgradeZone"))
+		{
+			MvMPlayer(client).IsSwitchingClass = true;
+		}
 		
 		SetEntProp(client, Prop_Send, "m_bInUpgradeZone", false);
 	}

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -191,10 +191,13 @@ public void Event_PlayerDeath(Event event, const char[] name, bool dontBroadcast
 			ResetMannVsMachineMode();
 		}
 		
-		if (!(death_flags & TF_DEATHFLAG_DEADRINGER) && !silent_kill)
+		if (!IsInArenaMode())
 		{
-			//Create revive marker
-			SetEntDataEnt2(victim, g_OffsetPlayerReviveMarker, SDKCall_ReviveMarkerCreate(victim));
+			if (!(death_flags & TF_DEATHFLAG_DEADRINGER) && !silent_kill)
+			{
+				//Create revive marker
+				SetEntDataEnt2(victim, g_OffsetPlayerReviveMarker, SDKCall_ReviveMarkerCreate(victim));
+			}
 		}
 	}
 }

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -219,10 +219,12 @@ public void Event_PlayerSpawn(Event event, const char[] name, bool dontBroadcast
 
 public void Event_PlayerChangeClass(Event event, const char[] name, bool dontBroadcast)
 {
+	int client = GetClientOfUserId(event.GetInt("userid"));
+	
+	EmitGameSoundToClient(client, "music.mvm_class_select");
+	
 	if (IsInArenaMode())
 	{
-		int client = GetClientOfUserId(event.GetInt("userid"));
-		
 		if (GetEntProp(client, Prop_Send, "m_bInUpgradeZone"))
 		{
 			MvMPlayer(client).IsClosingUpgradeMenu = true;

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -223,11 +223,6 @@ public void Event_PlayerChangeClass(Event event, const char[] name, bool dontBro
 	{
 		int client = GetClientOfUserId(event.GetInt("userid"));
 		
-		//NOTE: Attempting to close an open upgrade menu in player_class and reopening it in post_inventory_application
-		//will lead to it staying open with the previous layout since it did not have enough time to close clientside.
-		//To work around this issue, we wait for the menu to be fully closed before reopening it by listening to
-		//the MvM_UpgradesDone KeyValues client command (see: OnClientCommandKeyValues).
-		
 		if (GetEntProp(client, Prop_Send, "m_bInUpgradeZone"))
 		{
 			MvMPlayer(client).IsClosingUpgradeMenu = true;

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -129,7 +129,7 @@ public void Event_PostInventoryApplication(Event event, const char[] name, bool 
 		TF2Attrib_SetByName(client, "revive", 1.0);
 	}
 	
-	if (IsInArenaMode() && !MvMPlayer(client).IsClosingUpgradeMenu)
+	if (IsInArenaMode() && GameRules_GetRoundState() == RoundState_Preround && !MvMPlayer(client).IsClosingUpgradeMenu)
 	{
 		//Automatically open the upgrade menu on spawn
 		SetEntProp(client, Prop_Send, "m_bInUpgradeZone", true);

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -129,7 +129,7 @@ public void Event_PostInventoryApplication(Event event, const char[] name, bool 
 		TF2Attrib_SetByName(client, "revive", 1.0);
 	}
 	
-	if (IsInArenaMode() && !MvMPlayer(client).IsSwitchingClass)
+	if (IsInArenaMode() && !MvMPlayer(client).IsClosingUpgradeMenu)
 	{
 		//Automatically open the upgrade menu on spawn
 		SetEntProp(client, Prop_Send, "m_bInUpgradeZone", true);
@@ -230,7 +230,7 @@ public void Event_PlayerChangeClass(Event event, const char[] name, bool dontBro
 		
 		if (GetEntProp(client, Prop_Send, "m_bInUpgradeZone"))
 		{
-			MvMPlayer(client).IsSwitchingClass = true;
+			MvMPlayer(client).IsClosingUpgradeMenu = true;
 		}
 		
 		SetEntProp(client, Prop_Send, "m_bInUpgradeZone", false);

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -96,6 +96,11 @@ void ResetMannVsMachineMode()
 	GameRules_SetProp("m_bPlayingMannVsMachine", g_IsMannVsMachineModeState[index]);
 }
 
+bool IsInArenaMode()
+{
+	return GameRules_GetProp("m_nGameType") == TF_GAMETYPE_ARENA;
+}
+
 void CreateUpgradeStation(int regenerate)
 {
 	int upgradestation = CreateEntityByName("func_upgradestation");

--- a/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
+++ b/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
@@ -18,7 +18,7 @@
 static int g_PlayerTeamCount[MAXPLAYERS + 1];
 static TFTeam g_PlayerTeam[MAXPLAYERS + 1][8];
 static bool g_PlayerHasPurchasedUpgrades[MAXPLAYERS + 1];
-static bool g_PlayerIsSwitchingClass[MAXPLAYERS + 1];
+static bool g_PlayerIsClosingUpgradeMenu[MAXPLAYERS + 1];
 
 static int g_TeamAcquiredCredits[view_as<int>(TFTeam_Blue) + 1];
 static int g_TeamWorldCredits[view_as<int>(TFTeam_Blue) + 1];
@@ -50,15 +50,15 @@ methodmap MvMPlayer
 		}
 	}
 	
-	property bool IsSwitchingClass
+	property bool IsClosingUpgradeMenu
 	{
 		public get()
 		{
-			return g_PlayerIsSwitchingClass[this];
+			return g_PlayerIsClosingUpgradeMenu[this];
 		}
 		public set(bool val)
 		{
-			g_PlayerIsSwitchingClass[this] = val;
+			g_PlayerIsClosingUpgradeMenu[this] = val;
 		}
 	}
 	

--- a/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
+++ b/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
@@ -94,6 +94,12 @@ methodmap MvMPlayer
 		FakeClientCommandKeyValues(this.Client, respec);
 		delete respec;
 	}
+	
+	public void Reset()
+	{
+		this.HasPurchasedUpgrades = false;
+		this.IsClosingUpgradeMenu = false;
+	}
 }
 
 methodmap MvMTeam

--- a/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
+++ b/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
@@ -18,6 +18,7 @@
 static int g_PlayerTeamCount[MAXPLAYERS + 1];
 static TFTeam g_PlayerTeam[MAXPLAYERS + 1][8];
 static bool g_PlayerHasPurchasedUpgrades[MAXPLAYERS + 1];
+static bool g_PlayerIsSwitchingClass[MAXPLAYERS + 1];
 
 static int g_TeamAcquiredCredits[view_as<int>(TFTeam_Blue) + 1];
 static int g_TeamWorldCredits[view_as<int>(TFTeam_Blue) + 1];
@@ -46,6 +47,18 @@ methodmap MvMPlayer
 		public set(bool val)
 		{
 			g_PlayerHasPurchasedUpgrades[this] = val;
+		}
+	}
+	
+	property bool IsSwitchingClass
+	{
+		public get()
+		{
+			return g_PlayerIsSwitchingClass[this];
+		}
+		public set(bool val)
+		{
+			g_PlayerIsSwitchingClass[this] = val;
 		}
 	}
 	

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -150,7 +150,7 @@ public void Sapper_SpawnPost(int sapper)
 
 public Action RespawnRoom_Touch(int respawnroom, int other)
 {
-	if (mvm_spawn_protection.BoolValue && GameRules_GetRoundState() != RoundState_TeamWin)
+	if (!IsInArenaMode() && mvm_spawn_protection.BoolValue && GameRules_GetRoundState() != RoundState_TeamWin)
 	{
 		//Players get uber while they leave their spawn so they don't drop their cash where enemies can't pick it up
 		if (!GetEntProp(respawnroom, Prop_Data, "m_bDisabled") && IsValidClient(other) && TF2_GetTeam(respawnroom) == TF2_GetClientTeam(other))


### PR DESCRIPTION
Adds support for TF2's arena mode. It has some quirks but works fine.

* Upgrade menu opens during arena preround time on spawn and class switch
* Players do not create revive markers when they die
* No spawn protection