### PR TITLE
Various fixes related to the "player_death" event

### DIFF
--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -26,7 +26,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.2.0"
+#define PLUGIN_VERSION	"1.2.1"
 
 #define TF_GAMETYPE_ARENA		4
 #define MEDIGUN_CHARGE_INVULN	0

--- a/addons/sourcemod/scripting/mannvsmann/sdkcalls.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkcalls.sp
@@ -23,6 +23,7 @@ static Handle g_SDKCallGetEquippedWearableForLoadoutSlot;
 static Handle g_SDKCallCanRecieveMedigunChargeEffect;
 static Handle g_SDKCallReviveMarkerCreate;
 static Handle g_SDKCallRemoveImmediate;
+static Handle g_SDKCallDistributeCurrencyAmount;
 static Handle g_SDKCallGetBaseEntity;
 static Handle g_SDKCallShouldSwitchTeams;
 static Handle g_SDKCallShouldScrambleTeams;
@@ -38,6 +39,7 @@ void SDKCalls_Initialize(GameData gamedata)
 	g_SDKCallCanRecieveMedigunChargeEffect = PrepSDKCall_CanRecieveMedigunChargeEffect(gamedata);
 	g_SDKCallReviveMarkerCreate = PrepSDKCall_ReviveMarkerCreate(gamedata);
 	g_SDKCallRemoveImmediate = PrepSDKCall_RemoveImmediate(gamedata);
+	g_SDKCallDistributeCurrencyAmount = PrepSDKCall_DistributeCurrencyAmount(gamedata);
 	g_SDKCallGetBaseEntity = PrepSDKCall_GetBaseEntity(gamedata);
 	g_SDKCallShouldSwitchTeams = PrepSDKCall_ShouldSwitchTeams(gamedata);
 	g_SDKCallShouldScrambleTeams = PrepSDKCall_ShouldScrambleTeams(gamedata);
@@ -155,6 +157,24 @@ Handle PrepSDKCall_RemoveImmediate(GameData gamedata)
 	return call;
 }
 
+Handle PrepSDKCall_DistributeCurrencyAmount(GameData gamedata)
+{
+	StartPrepSDKCall(SDKCall_GameRules);
+	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CTFGameRules::DistributeCurrencyAmount");
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_AddParameter(SDKType_CBasePlayer, SDKPass_Pointer, VDECODE_FLAG_ALLOWNULL);
+	PrepSDKCall_AddParameter(SDKType_Bool, SDKPass_ByValue);
+	PrepSDKCall_AddParameter(SDKType_Bool, SDKPass_ByValue);
+	PrepSDKCall_AddParameter(SDKType_Bool, SDKPass_ByValue);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+	
+	Handle call = EndPrepSDKCall();
+	if (!call)
+		LogMessage("Failed to create SDK call: CTFGameRules::DistributeCurrencyAmount");
+	
+	return call;
+}
+
 Handle PrepSDKCall_GetBaseEntity(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Raw);
@@ -263,6 +283,14 @@ void SDKCall_RemoveImmediate(int entity)
 {
 	if (g_SDKCallRemoveImmediate)
 		SDKCall(g_SDKCallRemoveImmediate, entity);
+}
+
+int SDKCall_DistributeCurrencyAmount(int amount, int player = -1, bool shared = true, bool countAsDropped = false, bool isBonus = false)
+{
+	if (g_SDKCallDistributeCurrencyAmount)
+		return SDKCall(g_SDKCallDistributeCurrencyAmount, amount, player, shared, countAsDropped, isBonus);
+	else
+		return 0;
 }
 
 int SDKCall_GetBaseEntity(Address address)


### PR DESCRIPTION
* Fixed explosive headshot bleed kills not automatically distributing credits
* Fixed the `mvm_sniper_headshot_currency` event not firing
* Fixed revive markers not being created for environmental deaths or suicides
* Fixed a bug that in rare cases would create two revive markers for players
* Fixed currency not being automatically distributed when the player died to a trigger