### PR TITLE
Fix refunding currency and resetting upgrades twice

### DIFF
--- a/addons/sourcemod/gamedata/mannvsmann.txt
+++ b/addons/sourcemod/gamedata/mannvsmann.txt
@@ -29,6 +29,11 @@
 				"linux"		"@_ZN18CPopulationManager22AddPlayerCurrencySpentEP9CTFPlayeri"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x08\x81\x65\xFC\xFF\xFF\x0F\xFF\x8D\x45\xF8\x56\x8B\x75\x08\x57\x8B\xF9\xC6\x45\xFF\x00\x81\x65\xFC\x00\x00\xF0\xFF\x8B\xCE\x50\xC7\x45\xF8\x00\x00\x00\x00\xE8\x2A\x2A\x2A\x2A\x84\xC0\x75\x2A\x8D\x86\x84\x0E\x00\x00\x50\x68\x2A\x2A\x2A\x2A\xFF\x15\x2A\x2A\x2A\x2A\x83\xC4\x08\x5F"
 			}
+			"CPopulationManager::RemovePlayerAndItemUpgradesFromHistory"
+			{
+				"linux"		"@_ZN18CPopulationManager38RemovePlayerAndItemUpgradesFromHistoryEP9CTFPlayer"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x14\x81\x65\xF0\xFF\xFF\x0F\xFF"
+			}
 			"CTFGameRules::IsQuickBuildTime"
 			{
 				"linux"		"@_ZN12CTFGameRules16IsQuickBuildTimeEv"
@@ -242,6 +247,20 @@
 				"callconv"	"thiscall"
 				"return"	"void"
 				"this"		"entity"
+			}
+			"CPopulationManager::RemovePlayerAndItemUpgradesFromHistory"
+			{
+				"signature"	"CPopulationManager::RemovePlayerAndItemUpgradesFromHistory"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pPlayer"
+					{
+						"type"	"cbaseentity"
+					}
+				}
 			}
 			"CTFGameRules::IsQuickBuildTime"
 			{

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -26,7 +26,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.2.1"
+#define PLUGIN_VERSION	"1.2.2"
 
 #define TF_GAMETYPE_ARENA		4
 #define MEDIGUN_CHARGE_INVULN	0

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -31,6 +31,7 @@ void DHooks_Initialize(GameData gamedata)
 	CreateDynamicDetour(gamedata, "CUpgrades::ApplyUpgradeToItem", DHookCallback_ApplyUpgradeToItem_Pre, DHookCallback_ApplyUpgradeToItem_Post);
 	CreateDynamicDetour(gamedata, "CPopulationManager::Update", DHookCallback_PopulationManagerUpdate_Pre, _);
 	CreateDynamicDetour(gamedata, "CPopulationManager::ResetMap", DHookCallback_PopulationManagerResetMap_Pre, DHookCallback_PopulationManagerResetMap_Post);
+	CreateDynamicDetour(gamedata, "CPopulationManager::RemovePlayerAndItemUpgradesFromHistory", DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Pre, DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Post);
 	CreateDynamicDetour(gamedata, "CTFGameRules::IsQuickBuildTime", DHookCallback_IsQuickBuildTime_Pre, DHookCallback_IsQuickBuildTime_Post);
 	CreateDynamicDetour(gamedata, "CTFGameRules::GameModeUsesUpgrades", _, DHookCallback_GameModeUsesUpgrades_Post);
 	CreateDynamicDetour(gamedata, "CTFGameRules::CanPlayerUseRespec", DHookCallback_CanPlayerUseRespec_Pre, DHookCallback_CanPlayerUseRespec_Post);
@@ -156,6 +157,18 @@ public MRESReturn DHookCallback_PopulationManagerResetMap_Post()
 			MvMPlayer(client).ResetTeam();
 		}
 	}
+}
+
+public MRESReturn DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Pre(int populator, DHookParam params)
+{
+	//This function handles refunding currency and resetting upgrade history during a respec
+	//Block this, as we already handle it ourselves in the respec menu handler
+	SetMannVsMachineMode(false);
+}
+
+public MRESReturn DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Post(int populator, DHookParam params)
+{
+	ResetMannVsMachineMode();
 }
 
 public MRESReturn DHookCallback_IsQuickBuildTime_Pre()


### PR DESCRIPTION
Fixes #6

`CPopulationManager::RemovePlayerAndItemUpgradesFromHistory` will refund currency and reset upgrade history even though we already handle this ourselves in our respec menu handler. This causes problems, such as lingering upgrades or inaccurate currency amounts after a respec. Luckily, this block of code specifically is gated by an MvM check, so we can turn it off for this function call.