### PR TITLE
Track player currency rewards

### DIFF
--- a/addons/sourcemod/gamedata/mannvsmann.txt
+++ b/addons/sourcemod/gamedata/mannvsmann.txt
@@ -34,6 +34,11 @@
 				"linux"		"@_ZN18CPopulationManager38RemovePlayerAndItemUpgradesFromHistoryEP9CTFPlayer"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x14\x81\x65\xF0\xFF\xFF\x0F\xFF"
 			}
+			"CCaptureFlag::Capture"
+			{
+				"linux"		"@_ZN12CCaptureFlag7CaptureEP9CTFPlayeri"
+				"windows"	"\x55\x8B\xEC\x81\xEC\x80\x00\x00\x00\x57\x8B\xF9"
+			}
 			"CTFGameRules::IsQuickBuildTime"
 			{
 				"linux"		"@_ZN12CTFGameRules16IsQuickBuildTimeEv"
@@ -262,6 +267,24 @@
 					}
 				}
 			}
+			"CCaptureFlag::Capture"
+			{
+				"signature"	"CCaptureFlag::Capture"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pPlayer"
+					{
+						"type"	"cbaseentity"
+					}
+					"nCapturePoint"
+					{
+						"type"	"int"
+					}
+				}
+			}
 			"CTFGameRules::IsQuickBuildTime"
 			{
 				"signature"	"CTFGameRules::IsQuickBuildTime"
@@ -366,7 +389,7 @@
 			{
 				"signature"	"CTFPlayer::CanBuild"
 				"callconv"	"thiscall"
-				"return"	"void"
+				"return"	"int"
 				"this"		"entity"
 				"arguments"
 				{

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -26,7 +26,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.2.2"
+#define PLUGIN_VERSION	"1.2.3"
 
 #define TF_GAMETYPE_ARENA		4
 #define MEDIGUN_CHARGE_INVULN	0
@@ -230,10 +230,7 @@ public void OnMapEnd()
 public void OnClientPutInServer(int client)
 {
 	SDKHooks_HookClient(client);
-}
-
-public void OnClientDisconnect(int client)
-{
+	
 	MvMPlayer(client).Reset();
 }
 
@@ -276,7 +273,7 @@ public void OnEntityDestroyed(int entity)
 			if (!GetEntProp(entity, Prop_Send, "m_bDistributed"))
 			{
 				TFTeam team = TF2_GetTeam(entity);
-				MvMTeam(team).WorldCredits -= GetEntData(entity, g_OffsetCurrencyPackAmount);
+				MvMTeam(team).WorldMoney -= GetEntData(entity, g_OffsetCurrencyPackAmount);
 			}
 		}
 		else if (strncmp(classname, "func_upgradestation", 17) == 0)
@@ -519,13 +516,13 @@ public Action Timer_UpdateHudText(Handle timer)
 				//Show players how much currency they have outside of upgrade stations
 				if (!GetEntProp(client, Prop_Send, "m_bInUpgradeZone"))
 				{
-					ShowSyncHudText(client, g_HudSync, "$%d ($%d)", MvMPlayer(client).Currency, MvMTeam(team).WorldCredits);
+					ShowSyncHudText(client, g_HudSync, "$%d ($%d)", MvMPlayer(client).Currency, MvMTeam(team).WorldMoney);
 				}
 			}
 			else if (team == TFTeam_Spectator)
 			{
 				//Spectators can see currency stats for each team
-				ShowSyncHudText(client, g_HudSync, "BLU: $%d ($%d)\nRED: $%d ($%d)", MvMTeam(TFTeam_Blue).AcquiredCredits, MvMTeam(TFTeam_Blue).WorldCredits, MvMTeam(TFTeam_Red).AcquiredCredits, MvMTeam(TFTeam_Red).WorldCredits);
+				ShowSyncHudText(client, g_HudSync, "BLU: $%d ($%d)\nRED: $%d ($%d)", MvMTeam(TFTeam_Blue).AcquiredCredits, MvMTeam(TFTeam_Blue).WorldMoney, MvMTeam(TFTeam_Red).AcquiredCredits, MvMTeam(TFTeam_Red).WorldMoney);
 			}
 		}
 	}
@@ -548,7 +545,7 @@ public int MenuHandler_UpgradeRespec(Menu menu, MenuAction action, int param1, i
 					if (populator != -1)
 					{
 						//This should put us at the right currency, given that we've removed item and player upgrade tracking by this point
-						int totalAcquiredCurrency = MvMTeam(TF2_GetClientTeam(param1)).AcquiredCredits + mvm_currency_starting.IntValue;
+						int totalAcquiredCurrency = MvMTeam(TF2_GetClientTeam(param1)).AcquiredCredits + MvMPlayer(param1).AcquiredCredits + mvm_currency_starting.IntValue;
 						int spentCurrency = SDKCall_GetPlayerCurrencySpent(populator, param1);
 						MvMPlayer(param1).Currency = totalAcquiredCurrency - spentCurrency;
 					}

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -155,7 +155,7 @@ public void Event_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
 		if (populator != -1)
 		{
 			//This should put us at the right currency, given that we've removed item and player upgrade tracking by this point
-			int totalAcquiredCurrency = MvMTeam(team).AcquiredCredits + mvm_currency_starting.IntValue;
+			int totalAcquiredCurrency = MvMTeam(team).AcquiredCredits + MvMPlayer(client).AcquiredCredits + mvm_currency_starting.IntValue;
 			int spentCurrency = SDKCall_GetPlayerCurrencySpent(populator, client);
 			MvMPlayer(client).Currency = totalAcquiredCurrency - spentCurrency;
 		}

--- a/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
+++ b/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
@@ -15,15 +15,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+//MvMPlayer properties
 static int g_PlayerTeamCount[MAXPLAYERS + 1];
 static TFTeam g_PlayerTeam[MAXPLAYERS + 1][8];
 static int g_PlayerIsMiniBossCount[MAXPLAYERS + 1];
 static int g_PlayerIsMiniBoss[MAXPLAYERS + 1][8];
 static bool g_PlayerHasPurchasedUpgrades[MAXPLAYERS + 1];
 static bool g_PlayerIsClosingUpgradeMenu[MAXPLAYERS + 1];
+static int g_PlayerAcquiredCredits[MAXPLAYERS + 1];
 
+//MvMTeam properties
 static int g_TeamAcquiredCredits[view_as<int>(TFTeam_Blue) + 1];
-static int g_TeamWorldCredits[view_as<int>(TFTeam_Blue) + 1];
+static int g_TeamWorldMoney[view_as<int>(TFTeam_Blue) + 1];
 
 methodmap MvMPlayer
 {
@@ -46,9 +49,9 @@ methodmap MvMPlayer
 		{
 			return g_PlayerHasPurchasedUpgrades[this];
 		}
-		public set(bool val)
+		public set(bool value)
 		{
-			g_PlayerHasPurchasedUpgrades[this] = val;
+			g_PlayerHasPurchasedUpgrades[this] = value;
 		}
 	}
 	
@@ -58,9 +61,21 @@ methodmap MvMPlayer
 		{
 			return g_PlayerIsClosingUpgradeMenu[this];
 		}
-		public set(bool val)
+		public set(bool value)
 		{
-			g_PlayerIsClosingUpgradeMenu[this] = val;
+			g_PlayerIsClosingUpgradeMenu[this] = value;
+		}
+	}
+	
+	property int AcquiredCredits
+	{
+		public get()
+		{
+			return g_PlayerAcquiredCredits[this];
+		}
+		public set(int value)
+		{
+			g_PlayerAcquiredCredits[this] = value;
 		}
 	}
 	
@@ -70,9 +85,9 @@ methodmap MvMPlayer
 		{
 			return GetEntProp(this.Client, Prop_Send, "m_nCurrency");
 		}
-		public set(int val)
+		public set(int value)
 		{
-			SetEntProp(this.Client, Prop_Send, "m_nCurrency", val);
+			SetEntProp(this.Client, Prop_Send, "m_nCurrency", value);
 		}
 	}
 	
@@ -114,6 +129,7 @@ methodmap MvMPlayer
 	{
 		this.HasPurchasedUpgrades = false;
 		this.IsClosingUpgradeMenu = false;
+		this.AcquiredCredits = 0;
 	}
 }
 
@@ -130,21 +146,21 @@ methodmap MvMTeam
 		{
 			return g_TeamAcquiredCredits[this];
 		}
-		public set(int val)
+		public set(int value)
 		{
-			g_TeamAcquiredCredits[this] = val;
+			g_TeamAcquiredCredits[this] = value;
 		}
 	}
 	
-	property int WorldCredits
+	property int WorldMoney
 	{
 		public get()
 		{
-			return g_TeamWorldCredits[this];
+			return g_TeamWorldMoney[this];
 		}
-		public set(int val)
+		public set(int value)
 		{
-			g_TeamWorldCredits[this] = val;
+			g_TeamWorldMoney[this] = value;
 		}
 	}
 }

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -121,7 +121,7 @@ public void CurrencyPack_SpawnPost(int currencypack)
 	if (!GetEntProp(currencypack, Prop_Send, "m_bDistributed"))
 	{
 		TFTeam team = TF2_GetTeam(currencypack);
-		MvMTeam(team).WorldCredits += GetEntData(currencypack, g_OffsetCurrencyPackAmount);
+		MvMTeam(team).WorldMoney += GetEntData(currencypack, g_OffsetCurrencyPackAmount);
 	}
 	
 	SetEdictFlags(currencypack, (GetEdictFlags(currencypack) & ~FL_EDICT_ALWAYS));


### PR DESCRIPTION
Some actions in TF2 will distribute currency to one or more specific players instead of an entire team (e.g. capturing a point will award $100 to all cappers).
This becomes problematic and may put the player at negative currency when they refund upgrades purchased with it, since we only track acquired currency for entire teams, not individual players.

This PR aims to change that by adding a new `AcquiredCredits` property to the player, which persists across team changes.

Additionally, it fixes a bug where capturing a flag would not award the player with currency.