### PR TITLE
Hook func_regenerate instead of creating upgrade stations

### DIFF
--- a/addons/sourcemod/gamedata/mannvsmann.txt
+++ b/addons/sourcemod/gamedata/mannvsmann.txt
@@ -146,6 +146,11 @@
 				"linux"		"@_ZN13CObjectSapper22ApplyRoboSapperEffectsEP9CTFPlayerf"
 				"windows"	"\x55\x8B\xEC\x53\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x75\x2A\x5F\x32\xC0\x5B\x5D\xC2\x08\x00"
 			}
+			"CRegenerateZone::Regenerate"
+			{
+				"linux"		"@_ZN15CRegenerateZone10RegenerateEP9CTFPlayer"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x34\x53\x56\x8B\x75\x08\x8B\xD9\x57"
+			}
 			"UTIL_RemoveImmediate"
 			{
 				"linux"		"@_Z20UTIL_RemoveImmediateP11CBaseEntity"
@@ -477,6 +482,20 @@
 					"flDuration"
 					{
 						"type"	"float"
+					}
+				}
+			}
+			"CRegenerateZone::Regenerate"
+			{
+				"signature"	"CRegenerateZone::Regenerate"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pPlayer"
+					{
+						"type"	"cbaseentity"
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -47,6 +47,7 @@ void DHooks_Initialize(GameData gamedata)
 	CreateDynamicDetour(gamedata, "CBaseObject::FindSnapToBuildPos", DHookCallback_FindSnapToBuildPos_Pre, DHookCallback_FindSnapToBuildPos_Post);
 	CreateDynamicDetour(gamedata, "CBaseObject::ShouldQuickBuild", DHookCallback_ShouldQuickBuild_Pre, DHookCallback_ShouldQuickBuild_Post);
 	CreateDynamicDetour(gamedata, "CObjectSapper::ApplyRoboSapperEffects", DHookCallback_ApplyRoboSapperEffects_Pre, DHookCallback_ApplyRoboSapperEffects_Post);
+	CreateDynamicDetour(gamedata, "CRegenerateZone::Regenerate", DHookCallback_Regenerate_Pre, _);
 	
 	g_DHookMyTouch = CreateDynamicHook(gamedata, "CCurrencyPack::MyTouch");
 	g_DHookComeToRest = CreateDynamicHook(gamedata, "CCurrencyPack::ComeToRest");
@@ -518,6 +519,13 @@ public MRESReturn DHookCallback_ApplyRoboSapperEffects_Post(int sapper, DHookRet
 	MvMPlayer(target).ResetIsMiniBoss();
 	
 	return MRES_Ignored;
+}
+
+public MRESReturn DHookCallback_Regenerate_Pre(int regenerate, DHookParam params)
+{
+	int player = params.Get(1);
+	
+	SetEntProp(player, Prop_Send, "m_bInUpgradeZone", true);
 }
 
 public MRESReturn DHookCallback_MyTouch_Pre(int currencypack, DHookReturn ret, DHookParam params)

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -141,21 +141,6 @@ bool IsInArenaMode()
 	return view_as<TFGameType>(GameRules_GetProp("m_nGameType")) == TF_GAMETYPE_ARENA;
 }
 
-void CreateUpgradeStation(int regenerate)
-{
-	int upgradestation = CreateEntityByName("func_upgradestation");
-	
-	// This saves us from copying various values (origin, mins, maxs, etc.)
-	char model[PLATFORM_MAX_PATH];
-	GetEntPropString(regenerate, Prop_Data, "m_ModelName", model, sizeof(model));
-	SetEntityModel(upgradestation, model);
-	
-	SetVariantString("!activator");
-	AcceptEntityInput(upgradestation, "SetParent", regenerate);
-	
-	DispatchSpawn(upgradestation);
-}
-
 int GetPlayingClientCount()
 {
 	int count;

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -27,7 +27,7 @@ void SDKHooks_OnEntityCreated(int entity, const char[] classname)
 {
 	if (strcmp(classname, "func_regenerate") == 0)
 	{
-		SDKHook(entity, SDKHook_Spawn, Regenerate_Spawn);
+		SDKHook(entity, SDKHook_EndTouch, Regenerate_EndTouch);
 	}
 	else if (strcmp(classname, "entity_revive_marker") == 0)
 	{
@@ -100,11 +100,11 @@ public void Client_OnTakeDamageAlivePost(int victim, int attacker, int inflictor
 	ResetMannVsMachineMode();
 }
 
-public void Regenerate_Spawn(int regenerate)
+public Action Regenerate_EndTouch(int regenerate, int other)
 {
-	if (g_IsMapRunning)
+	if (IsValidClient(other))
 	{
-		CreateUpgradeStation(regenerate);
+		SetEntProp(other, Prop_Send, "m_bInUpgradeZone", true);
 	}
 }
 


### PR DESCRIPTION
Closes #11 

Instead of creating an upgrade station for every `func_regenerate`, we now use the resupply trigger directly. This is how it worked in the original Bounty Mode and has the benefit of proper team checks.

This should also fix the issue of some maps having misplaced upgrade station triggers.