### PR TITLE
Add plugin toggle convar & clean up code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-![Mann vs. Mann Logo by RatX](https://repository-images.githubusercontent.com/359592641/ec8bd400-b132-11eb-8ae7-bf0809723735)
-
 # Mann vs. Mann
+
+![Mann vs. Mann Logo by RatX](https://repository-images.githubusercontent.com/359592641/ec8bd400-b132-11eb-8ae7-bf0809723735)
 
 **A custom Team Fortress 2 gamemode that puts Mann vs. Machine upgrades into regular gameplay.**
 
-Mann vs. Mann was originally created by [Screwdriver](https://github.com/ScrewdriverHyena)
-and [Kenzzer](https://github.com/Kenzzer) in 2018 for the Red Sun Over Paradise community. It was ultimately abandoned
-and never publicly released due to countless issues.
+Mann vs. Mann was originally created by [Screwdriver](https://github.com/ScrewdriverHyena) and [Kenzzer](https://github.com/Kenzzer) in 2018 for the Red Sun Over Paradise community.
+Development on it was ultimately stopped and the plugin was never released to the public.
 
-In April 2021, [Mikusch](https://github.com/Mikusch) decided to completely rewrite the plugin from the ground up with
-many needed fixes and additional gameplay elements.
+In April 2021, [Mikusch](https://github.com/Mikusch) decided to remake the plugin from the ground up with many fixes and additional gameplay elements.
 
 ## Features
 
@@ -20,13 +18,13 @@ many needed fixes and additional gameplay elements.
     - Buybacks
     - Revive Markers
     - ...and much more
-- Compatible with arena mode and any map with resupply lockers
+- Compatible with all official gamemodes (except Mann vs. Machine)
 - Support for custom upgrade files
 - Configurable using plugin ConVars
 
 ## Requirements
 
 - SourceMod 1.10+
-- [DHooks with Detour Support](https://github.com/peace-maker/DHooks2/tree/dynhooks)
-- [TF2Attributes](https://github.com/FlaminSarge/tf2attributes)
+- [TF2Attributes](https://github.com/nosoop/tf2attributes)
+- [DHooks 2 with Detour Support ](https://github.com/peace-maker/DHooks2/tree/dynhooks) (included in SM 1.11)
 - [MemoryPatch](https://github.com/Kenzzer/MemoryPatch) (compile only)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Mann vs. Mann Logo by RatX](https://repository-images.githubusercontent.com/359592641/ec8bd400-b132-11eb-8ae7-bf0809723735)
 
-**A custom Team Fortress 2 gamemode that puts Mann vs. Machine upgrades into regular gameplay.**
+**A custom Team Fortress 2 gamemode that mixes Mann vs. Machine mechanics with regular gameplay.**
 
 Mann vs. Mann was originally created by [Screwdriver](https://github.com/ScrewdriverHyena) and [Kenzzer](https://github.com/Kenzzer) in 2018 for the Red Sun Over Paradise community.
 Development on it was ultimately stopped and the plugin was never released to the public.
@@ -11,7 +11,7 @@ In April 2021, [Mikusch](https://github.com/Mikusch) decided to remake the plugi
 
 ## Features
 
-- Working Mann vs. Machine mechanics in regular gameplay
+- Fully functioning Mann vs. Machine mechanics in regular gameplay
     - Player and Item Upgrades
     - Power Up Canteens
     - Money Pickups

--- a/addons/sourcemod/gamedata/mannvsmann.txt
+++ b/addons/sourcemod/gamedata/mannvsmann.txt
@@ -609,26 +609,28 @@
 		}
 		"Addresses"
 		{
+			// Bypasses RED team check for radius currency collection
 			"MemoryPatch_RadiusCurrencyCollectionCheck"
 			{
 				"linux"
 				{
 					"signature"	"CTFPlayerShared::RadiusCurrencyCollectionCheck"
-					"offset"	"29"	//CTFPlayerShared::RadiusCurrencyCollectionCheck+1D
+					"offset"	"29"	// CTFPlayerShared::RadiusCurrencyCollectionCheck+1D
 				}
 				"windows"
 				{
 					"signature"	"CTFPlayerShared::RadiusCurrencyCollectionCheck"
-					"offset"	"26"	//CTFPlayerShared::RadiusCurrencyCollectionCheck+1A
+					"offset"	"26"	// CTFPlayerShared::RadiusCurrencyCollectionCheck+1A
 				}
 			}
 		}
 		"Keys"
 		{
-			"MemoryPatch_RadiusCurrencyCollectionCheck"	//m_pOuter->GetTeamNumber() != TF_TEAM_PVE_DEFENDERS
+			// m_pOuter->GetTeamNumber() != TF_TEAM_PVE_DEFENDERS
+			"MemoryPatch_RadiusCurrencyCollectionCheck"
 			{
-				"linux"		"\xEB"	//jz short -> jmp short
-				"windows"	"\xEB"	//jz short -> jmp short
+				"linux"		"\xEB"	// jz short -> jmp short
+				"windows"	"\xEB"	// jz short -> jmp short
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -240,7 +240,9 @@ public void OnPluginStart()
 public void OnPluginEnd()
 {
 	if (!g_IsEnabled)
+	{
 		return;
+	}
 	
 	TogglePlugin(false);
 }

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -420,15 +420,6 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				{
 					// Stop showing hints once the player has purchased an upgrade
 					MvMPlayer(client).HasPurchasedUpgrades = true;
-					
-					int upgrade = kv.GetNum("Upgrade");
-					int count = kv.GetNum("count");
-					
-					// Tell players how to build the Disposable Sentry
-					if (upgrade == 23 && count == 1)
-					{
-						PrintHintText(client, "%t", "MvM_Upgrade_DisposableSentry");
-					}
 				}
 			}
 			else if (!strcmp(section, "MvM_UpgradesBegin"))
@@ -446,6 +437,16 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				AcceptEntityInput(client, "AddContext");
 				
 				CancelClientMenu(client);
+				
+				// Tell Engineers how to build disposable sentries
+				if (TF2_GetPlayerClass(client) == TFClass_Engineer)
+				{
+					int melee = GetPlayerWeaponSlot(client, 3);
+					if (melee != -1 && TF2Attrib_GetByName(melee, "engy disposable sentries") != Address_Null)
+					{
+						PrintHintText(client, "%t", "MvM_Upgrade_DisposableSentry");
+					}
+				}
 				
 				if (IsInArenaMode())
 				{

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -442,7 +442,7 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				if (TF2_GetPlayerClass(client) == TFClass_Engineer)
 				{
 					int melee = GetPlayerWeaponSlot(client, 3);
-					if (melee != -1 && TF2Attrib_GetByName(melee, "engy disposable sentries") != Address_Null)
+					if (melee != -1 && TF2Attrib_GetByName(melee, "engy disposable sentries"))
 					{
 						PrintHintText(client, "%t", "MvM_Upgrade_DisposableSentry");
 					}
@@ -494,7 +494,7 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 			{
 				// Do not allow players to use ubercharge canteens if they are also unable to receive medigun charge effects
 				int powerupBottle = SDKCall_GetEquippedWearableForLoadoutSlot(client, view_as<int>(LOADOUT_POSITION_ACTION));
-				if (powerupBottle != -1 && TF2Attrib_GetByName(powerupBottle, "ubercharge") != Address_Null)
+				if (powerupBottle != -1 && TF2Attrib_GetByName(powerupBottle, "ubercharge"))
 				{
 					ResetMannVsMachineMode();
 					return Plugin_Handled;

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -578,6 +578,12 @@ void TogglePlugin(bool enable)
 		AddNormalSoundHook(NormalSoundHook);
 		HookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);
 		CreateTimer(0.1, Timer_UpdateHudText, _, TIMER_REPEAT);
+		
+		// Iterate all teams
+		for (TFTeam team = TFTeam_Unassigned; team <= TFTeam_Blue; team++)
+		{
+			MvMTeam(team).Reset();
+		}
 	}
 	else
 	{

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -653,11 +653,6 @@ public Action EntityOutput_OnTimer10SecRemain(const char[] output, int caller, i
 
 public Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &entity, int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
 {
-	if (!g_IsEnabled)
-	{
-		return Plugin_Continue;
-	}
-	
 	Action action = Plugin_Continue;
 	
 	if (IsValidEntity(entity))

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -15,6 +15,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>
@@ -23,10 +26,7 @@
 #include <tf2attributes>
 #include <memorypatch>
 
-#pragma semicolon 1
-#pragma newdecls required
-
-#define PLUGIN_VERSION	"1.5.1"
+#define PLUGIN_VERSION	"1.6.0"
 
 #define SOUND_CREDITS_UPDATED	"ui/credits_updated.wav"
 
@@ -154,6 +154,7 @@ enum
 }
 
 // ConVars
+ConVar mvm_enable;
 ConVar mvm_currency_starting;
 ConVar mvm_currency_rewards_player_killed;
 ConVar mvm_currency_rewards_player_count_bonus;
@@ -181,12 +182,14 @@ int g_OffsetRestoringCheckpoint;
 // Other globals
 Handle g_CurrencyHudSync;
 Handle g_BuybackHudSync;
+bool g_IsEnabled;
 bool g_IsMapRunning;
 bool g_ForceMapReset;
 int g_StartingCurrency;
 
 #include "mannvsmann/methodmaps.sp"
 
+#include "mannvsmann/convars.sp"
 #include "mannvsmann/dhooks.sp"
 #include "mannvsmann/events.sp"
 #include "mannvsmann/helpers.sp"
@@ -208,33 +211,10 @@ public void OnPluginStart()
 	LoadTranslations("common.phrases");
 	LoadTranslations("mannvsmann.phrases");
 	
-	CreateConVar("mvm_version", PLUGIN_VERSION, "Mann vs. Mann plugin version", FCVAR_SPONLY | FCVAR_REPLICATED | FCVAR_NOTIFY | FCVAR_DONTRECORD);
-	mvm_currency_starting = CreateConVar("mvm_currency_starting", "1000", "Number of credits that players get at the start of a match.", _, true, 0.0);
-	mvm_currency_rewards_player_killed = CreateConVar("mvm_currency_rewards_player_killed", "15", "The fixed number of credits dropped by players on death.");
-	mvm_currency_rewards_player_count_bonus = CreateConVar("mvm_currency_rewards_player_count_bonus", "2.0", "Multiplier to dropped currency that gradually increases up to this value until all player slots have been filled.", _, true, 1.0);
-	mvm_currency_rewards_player_catchup_max = CreateConVar("mvm_currency_rewards_player_catchup_max", "1.5", "Maximum currency bonus multiplier for losing teams.", _, true, 1.0);
-	mvm_currency_rewards_player_modifier_arena = CreateConVar("mvm_currency_rewards_player_modifier_arena", "2.0", "Multiplier to dropped currency in arena mode.");
-	mvm_currency_rewards_player_modifier_medieval = CreateConVar("mvm_currency_rewards_player_modifier_medieval", "0.33", "Multiplier to dropped currency in medieval mode.");
-	mvm_currency_hud_position_x = CreateConVar("mvm_currency_hud_position_x", "-1", "x coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
-	mvm_currency_hud_position_y = CreateConVar("mvm_currency_hud_position_y", "0.75", "y coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
-	mvm_upgrades_reset_mode = CreateConVar("mvm_upgrades_reset_mode", "0", "How player upgrades and credits are reset after a full round has been played. 0 = Reset if teams are being switched or scrambled. 1 = Always reset. 2 = Never reset.");
-	mvm_showhealth = CreateConVar("mvm_showhealth", "0", "When set to 1, shows a floating health icon over enemy players.");
-	mvm_showhealth.AddChangeHook(ConVarChanged_ShowHealth);
-	mvm_spawn_protection = CreateConVar("mvm_spawn_protection", "1", "When set to 1, players are granted ubercharge while they leave their spawn.");
-	mvm_enable_music = CreateConVar("mvm_enable_music", "1", "When set to 1, Mann vs. Machine music will play at the start and end of a round.");
-	mvm_nerf_upgrades = CreateConVar("mvm_nerf_upgrades", "1", "When set to 1, some upgrades will be modified to be fairer in player versus player modes.");
-	mvm_custom_upgrades_file = CreateConVar("mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
-	mvm_custom_upgrades_file.AddChangeHook(ConVarChanged_CustomUpgradesFile);
-	
-	HookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);
-	
-	AddNormalSoundHook(NormalSoundHook);
-	
 	g_CurrencyHudSync = CreateHudSynchronizer();
 	g_BuybackHudSync = CreateHudSynchronizer();
 	
-	CreateTimer(0.1, Timer_UpdateHudText, _, TIMER_REPEAT);
-	
+	ConVars_Initialize();
 	Events_Initialize();
 	
 	GameData gamedata = new GameData("mannvsmann");
@@ -255,69 +235,45 @@ public void OnPluginStart()
 	{
 		SetFailState("Could not find mannvsmann gamedata");
 	}
-	
-	for (int client = 1; client <= MaxClients; client++)
-	{
-		if (IsClientInGame(client))
-		{
-			OnClientPutInServer(client);
-		}
-	}
-	
-	for (int entity = MaxClients + 1; entity < GetMaxEntities(); entity++)
-	{
-		if (IsValidEntity(entity))
-		{
-			char classname[32];
-			if (GetEntityClassname(entity, classname, sizeof(classname)))
-			{
-				OnEntityCreated(entity, classname);
-			}
-		}
-	}
 }
 
 public void OnPluginEnd()
 {
-	Patches_Destroy();
+	if (!g_IsEnabled)
+		return;
 	
-	// Remove our populator
-	int populator = FindEntityByClassname(MaxClients + 1, "info_populator");
-	if (populator != -1)
-	{
-		// NOTE: We use RemoveImmediate because RemoveEntity deletes the populator a few frames later.
-		// This causes the global populator pointer to be set to NULL after we've created a new populator already.
-		SDKCall_RemoveImmediate(populator);
-	}
-	
-	// Remove entities created by the plugin
-	RemoveEntitiesByClassname("func_upgradestation");
-	RemoveEntitiesByClassname("item_currencypack*");
-	RemoveEntitiesByClassname("entity_revive_marker");
+	TogglePlugin(false);
 }
 
 public void OnMapStart()
 {
+	if (!g_IsEnabled)
+	{
+		return;
+	}
+	
 	g_IsMapRunning = true;
 	
 	PrecacheSound(SOUND_CREDITS_UPDATED);
-	
-	DHooks_HookGameRules();
-	
-	// Create an info_populator entity, which is required for some MvM mechanics
-	CreateEntityByName("info_populator");
-	
-	// Create an upgrade station to initialize the upgrade system
-	DispatchSpawn(CreateEntityByName("func_upgradestation"));
 }
 
 public void OnMapEnd()
 {
+	if (!g_IsEnabled)
+	{
+		return;
+	}
+	
 	g_IsMapRunning = false;
 }
 
 public void OnConfigsExecuted()
 {
+	if (g_IsEnabled != mvm_enable.BoolValue)
+	{
+		TogglePlugin(mvm_enable.BoolValue);
+	}
+	
 	// Set custom upgrades file on level init
 	char path[PLATFORM_MAX_PATH];
 	mvm_custom_upgrades_file.GetString(path, sizeof(path));
@@ -332,6 +288,11 @@ public void OnConfigsExecuted()
 
 public void OnClientPutInServer(int client)
 {
+	if (!g_IsEnabled)
+	{
+		return;
+	}
+	
 	SDKHooks_HookClient(client);
 	
 	MvMPlayer(client).Reset();
@@ -339,13 +300,23 @@ public void OnClientPutInServer(int client)
 
 public void TF2_OnWaitingForPlayersEnd()
 {
+	if (!g_IsEnabled)
+	{
+		return;
+	}
+	
 	g_ForceMapReset = true;
 }
 
 public void OnEntityCreated(int entity, const char[] classname)
 {
-	DHooks_OnEntityCreated(entity, classname);
-	SDKHooks_OnEntityCreated(entity, classname);
+	if (!g_IsEnabled)
+	{
+		return;
+	}
+	
+	DHooks_HookEntity(entity, classname);
+	SDKHooks_HookEntity(entity, classname);
 	
 	if (!strncmp(classname, "item_currencypack_", 18))
 	{
@@ -373,8 +344,15 @@ public void OnEntityCreated(int entity, const char[] classname)
 
 public void OnEntityDestroyed(int entity)
 {
-	if (!IsValidEntity(entity))
+	if (!g_IsEnabled)
+	{
 		return;
+	}
+	
+	if (!IsValidEntity(entity))
+	{
+		return;
+	}
 	
 	char classname[32];
 	if (GetEntityClassname(entity, classname, sizeof(classname)))
@@ -404,6 +382,11 @@ public void OnEntityDestroyed(int entity)
 
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2])
 {
+	if (!g_IsEnabled)
+	{
+		return Plugin_Continue;
+	}
+	
 	if (buttons & IN_ATTACK2)
 	{
 		char name[32];
@@ -421,6 +404,11 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 public void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float vel[3], const float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, const int mouse[2])
 {
+	if (!g_IsEnabled)
+	{
+		return;
+	}
+	
 	if (IsMannVsMachineMode())
 	{
 		ResetMannVsMachineMode();
@@ -429,6 +417,11 @@ public void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float
 
 public Action OnClientCommandKeyValues(int client, KeyValues kv)
 {
+	if (!g_IsEnabled)
+	{
+		return Plugin_Continue;
+	}
+	
 	char section[32];
 	if (kv.GetSectionName(section, sizeof(section)))
 	{
@@ -530,6 +523,11 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 
 public void OnClientCommandKeyValues_Post(int client, KeyValues kv)
 {
+	if (!g_IsEnabled)
+	{
+		return;
+	}
+	
 	if (IsMannVsMachineMode())
 	{
 		ResetMannVsMachineMode();
@@ -548,6 +546,11 @@ public void OnClientCommandKeyValues_Post(int client, KeyValues kv)
 
 public void TF2_OnConditionAdded(int client, TFCond condition)
 {
+	if (!g_IsEnabled)
+	{
+		return;
+	}
+	
 	if (condition == TFCond_UberchargedCanteen)
 	{
 		// Prevent players from receiving uber canteens if they are unable to be ubered by mediguns
@@ -558,38 +561,82 @@ public void TF2_OnConditionAdded(int client, TFCond condition)
 	}
 }
 
-public void ConVarChanged_ShowHealth(ConVar convar, const char[] oldValue, const char[] newValue)
+void TogglePlugin(bool enable)
 {
+	g_IsEnabled = enable;
+	
+	ConVars_Toggle(enable);
+	DHooks_Toggle(enable);
+	Events_Toggle(enable);
+	Patches_Toggle(enable);
+	
+	if (enable)
+	{
+		AddNormalSoundHook(NormalSoundHook);
+		HookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);
+		CreateTimer(0.1, Timer_UpdateHudText, _, TIMER_REPEAT);
+		
+		// Create a populator and an upgrade station, which enable some MvM features
+		CreateEntityByName("info_populator");
+		DispatchSpawn(CreateEntityByName("func_upgradestation"));
+	}
+	else
+	{
+		RemoveNormalSoundHook(NormalSoundHook);
+		UnhookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);
+		
+		// Remove our populator to avoid the server filling up with bots
+		int populator = FindEntityByClassname(MaxClients + 1, "info_populator");
+		if (populator != -1)
+		{
+			// Using RemoveImmediate is required because RemoveEntity deletes the populator a few frames later.
+			// This may cause the global populator pointer to be set to NULL even if a new populator was created.
+			SDKCall_RemoveImmediate(populator);
+		}
+		
+		// Remove other entities likely created by the plugin
+		RemoveEntitiesByClassname("func_upgradestation");
+		RemoveEntitiesByClassname("item_currencypack_*");
+		RemoveEntitiesByClassname("entity_revive_marker");
+	}
+	
+	// Iterate all in-game clients
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client))
 		{
-			if (convar.BoolValue)
+			if (enable)
 			{
-				TF2Attrib_SetByName(client, "mod see enemy health", 1.0);
+				OnClientPutInServer(client);
 			}
 			else
 			{
-				TF2Attrib_RemoveByName(client, "mod see enemy health");
+				SDKHooks_UnhookClient(client);
+				CancelClientMenu(client);
+				
+				// Close any open upgrade menu
+				SetEntProp(client, Prop_Send, "m_bInUpgradeZone", false);
 			}
 		}
 	}
-}
-
-public void ConVarChanged_CustomUpgradesFile(ConVar convar, const char[] oldValue, const char[] newValue)
-{
-	if (newValue[0] != '\0')
+	
+	// Iterate all valid entities
+	for (int entity = MaxClients + 1; entity < GetMaxEntities(); entity++)
 	{
-		SetCustomUpgradesFile(newValue);
-	}
-	else
-	{
-		int gamerules = FindEntityByClassname(MaxClients + 1, "tf_gamerules");
-		if (gamerules != -1)
+		if (IsValidEntity(entity))
 		{
-			// Reset to the default upgrades file
-			SetVariantString("scripts/items/mvm_upgrades.txt");
-			AcceptEntityInput(gamerules, "SetCustomUpgradesFile");
+			char classname[32];
+			if (GetEntityClassname(entity, classname, sizeof(classname)))
+			{
+				if (enable)
+				{
+					OnEntityCreated(entity, classname);
+				}
+				else
+				{
+					SDKHooks_UnhookEntity(entity, classname);
+				}
+			}
 		}
 	}
 }
@@ -614,6 +661,11 @@ public Action EntityOutput_OnTimer10SecRemain(const char[] output, int caller, i
 
 public Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &entity, int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
 {
+	if (!g_IsEnabled)
+	{
+		return Plugin_Continue;
+	}
+	
 	Action action = Plugin_Continue;
 	
 	if (IsValidEntity(entity))
@@ -648,6 +700,11 @@ public Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sam
 
 public Action Timer_UpdateHudText(Handle timer)
 {
+	if (!g_IsEnabled)
+	{
+		return Plugin_Stop;
+	}
+	
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client))

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -250,23 +250,11 @@ public void OnPluginEnd()
 
 public void OnMapStart()
 {
-	if (!g_IsEnabled)
-	{
-		return;
-	}
-	
 	g_IsMapRunning = true;
-	
-	PrecacheSound(SOUND_CREDITS_UPDATED);
 }
 
 public void OnMapEnd()
 {
-	if (!g_IsEnabled)
-	{
-		return;
-	}
-	
 	g_IsMapRunning = false;
 }
 
@@ -563,6 +551,8 @@ void TogglePlugin(bool enable)
 	
 	if (enable)
 	{
+		PrecacheSound(SOUND_CREDITS_UPDATED);
+		
 		AddNormalSoundHook(NormalSoundHook);
 		HookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);
 		CreateTimer(0.1, Timer_UpdateHudText, _, TIMER_REPEAT);

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -315,8 +315,8 @@ public void OnEntityCreated(int entity, const char[] classname)
 		return;
 	}
 	
-	DHooks_HookEntity(entity, classname);
-	SDKHooks_HookEntity(entity, classname);
+	DHooks_OnEntityCreated(entity, classname);
+	SDKHooks_OnEntityCreated(entity, classname);
 	
 	if (!strncmp(classname, "item_currencypack_", 18))
 	{

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -169,7 +169,8 @@ ConVar mvm_upgrades_reset_mode;
 ConVar mvm_showhealth;
 ConVar mvm_spawn_protection;
 ConVar mvm_enable_music;
-ConVar mvm_nerf_upgrades;
+ConVar mvm_gas_explode_damage_modifier;
+ConVar mvm_medigun_shield_damage_modifier;
 ConVar mvm_custom_upgrades_file;
 
 // DHooks

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -641,6 +641,12 @@ void TogglePlugin(bool enable)
 			}
 		}
 	}
+	
+	// Restart the game to apply our changes
+	if (GameRules_GetRoundState() >= RoundState_Preround && !GameRules_GetProp("m_bInWaitingForPlayers"))
+	{
+		ServerCommand("mp_restartgame_immediate 1");
+	}
 }
 
 public Action EntityOutput_OnTimer10SecRemain(const char[] output, int caller, int activator, float delay)

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -264,6 +264,10 @@ public void OnConfigsExecuted()
 	{
 		TogglePlugin(mvm_enable.BoolValue);
 	}
+	else if (g_IsEnabled)
+	{
+		SetupOnMapStart();
+	}
 }
 
 public void OnClientPutInServer(int client)
@@ -540,6 +544,19 @@ public void TF2_OnConditionAdded(int client, TFCond condition)
 	}
 }
 
+void SetupOnMapStart()
+{
+	PrecacheSound(SOUND_CREDITS_UPDATED);
+	
+	// Set custom upgrades file and add it to downloads
+	char path[PLATFORM_MAX_PATH];
+	mvm_custom_upgrades_file.GetString(path, sizeof(path));
+	if (path[0] != '\0')
+	{
+		SetCustomUpgradesFile(path);
+	}
+}
+
 void TogglePlugin(bool enable)
 {
 	g_IsEnabled = enable;
@@ -551,7 +568,7 @@ void TogglePlugin(bool enable)
 	
 	if (enable)
 	{
-		PrecacheSound(SOUND_CREDITS_UPDATED);
+		SetupOnMapStart();
 		
 		AddNormalSoundHook(NormalSoundHook);
 		HookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);
@@ -560,14 +577,6 @@ void TogglePlugin(bool enable)
 		// Create a populator and an upgrade station, which enable some MvM features
 		CreateEntityByName("info_populator");
 		DispatchSpawn(CreateEntityByName("func_upgradestation"));
-		
-		// Set custom upgrades file
-		char path[PLATFORM_MAX_PATH];
-		mvm_custom_upgrades_file.GetString(path, sizeof(path));
-		if (path[0] != '\0')
-		{
-			SetCustomUpgradesFile(path);
-		}
 	}
 	else
 	{

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -555,6 +555,10 @@ void SetupOnMapStart()
 	{
 		SetCustomUpgradesFile(path);
 	}
+	
+	// Create a populator and an upgrade station, which enable some MvM features
+	CreateEntityByName("info_populator");
+	DispatchSpawn(CreateEntityByName("func_upgradestation"));
 }
 
 void TogglePlugin(bool enable)
@@ -573,10 +577,6 @@ void TogglePlugin(bool enable)
 		AddNormalSoundHook(NormalSoundHook);
 		HookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);
 		CreateTimer(0.1, Timer_UpdateHudText, _, TIMER_REPEAT);
-		
-		// Create a populator and an upgrade station, which enable some MvM features
-		CreateEntityByName("info_populator");
-		DispatchSpawn(CreateEntityByName("func_upgradestation"));
 	}
 	else
 	{

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2021  Mikusch
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+void ConVars_Initialize()
+{
+	CreateConVar("mvm_version", PLUGIN_VERSION, "Mann vs. Mann plugin version", FCVAR_SPONLY | FCVAR_REPLICATED | FCVAR_NOTIFY | FCVAR_DONTRECORD);
+	mvm_enable = CreateConVar("mvm_enable", "1", "When set, the plugin will be enabled.");
+	mvm_currency_starting = CreateConVar("mvm_currency_starting", "1000", "Number of credits that players get at the start of a match.", _, true, 0.0);
+	mvm_currency_rewards_player_killed = CreateConVar("mvm_currency_rewards_player_killed", "15", "The fixed number of credits dropped by players on death.");
+	mvm_currency_rewards_player_count_bonus = CreateConVar("mvm_currency_rewards_player_count_bonus", "2.0", "Multiplier to dropped currency that gradually increases up to this value until all player slots have been filled.", _, true, 1.0);
+	mvm_currency_rewards_player_catchup_max = CreateConVar("mvm_currency_rewards_player_catchup_max", "1.5", "Maximum currency bonus multiplier for losing teams.", _, true, 1.0);
+	mvm_currency_rewards_bonus_arena = CreateConVar("mvm_currency_rewards_bonus_arena", "2.0", "Multiplier to dropped currency in arena mode.", _, true, 1.0);
+	mvm_currency_hud_position_x = CreateConVar("mvm_currency_hud_position_x", "-1", "x coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
+	mvm_currency_hud_position_y = CreateConVar("mvm_currency_hud_position_y", "0.75", "y coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
+	mvm_upgrades_reset_mode = CreateConVar("mvm_upgrades_reset_mode", "0", "How player upgrades and credits are reset after a full round has been played. 0 = Reset if teams are being switched or scrambled. 1 = Always reset. 2 = Never reset.");
+	mvm_showhealth = CreateConVar("mvm_showhealth", "0", "When set to 1, shows a floating health icon over enemy players.");
+	mvm_spawn_protection = CreateConVar("mvm_spawn_protection", "1", "When set to 1, players are granted ubercharge while they leave their spawn.");
+	mvm_enable_music = CreateConVar("mvm_enable_music", "1", "When set to 1, Mann vs. Machine music will play at the start and end of a round.");
+	mvm_nerf_upgrades = CreateConVar("mvm_nerf_upgrades", "1", "When set to 1, some upgrades will be modified to be fairer in player versus player modes.");
+	mvm_custom_upgrades_file = CreateConVar("mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
+	
+	// Always keep this hook active
+	mvm_enable.AddChangeHook(ConVarChanged_Enable);
+}
+
+void ConVars_Toggle(bool enable)
+{
+	if (enable)
+	{
+		mvm_showhealth.AddChangeHook(ConVarChanged_ShowHealth);
+		mvm_custom_upgrades_file.AddChangeHook(ConVarChanged_CustomUpgradesFile);
+	}
+	else
+	{
+		mvm_showhealth.RemoveChangeHook(ConVarChanged_ShowHealth);
+		mvm_custom_upgrades_file.RemoveChangeHook(ConVarChanged_CustomUpgradesFile);
+	}
+}
+
+public void ConVarChanged_Enable(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	if (g_IsEnabled != convar.BoolValue)
+	{
+		TogglePlugin(convar.BoolValue);
+	}
+}
+
+public void ConVarChanged_ShowHealth(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	if (!g_IsEnabled)
+		return;
+	
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (IsClientInGame(client))
+		{
+			if (convar.BoolValue)
+			{
+				TF2Attrib_SetByName(client, "mod see enemy health", 1.0);
+			}
+			else
+			{
+				TF2Attrib_RemoveByName(client, "mod see enemy health");
+			}
+		}
+	}
+}
+
+public void ConVarChanged_CustomUpgradesFile(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	if (!g_IsEnabled)
+		return;
+	
+	if (newValue[0] != '\0')
+	{
+		// Set our custom upgrades file
+		SetCustomUpgradesFile(newValue);
+	}
+	else
+	{
+		int gamerules = FindEntityByClassname(MaxClients + 1, "tf_gamerules");
+		if (gamerules != -1)
+		{
+			// Reset to the default upgrades file
+			SetVariantString("scripts/items/mvm_upgrades.txt");
+			AcceptEntityInput(gamerules, "SetCustomUpgradesFile");
+		}
+	}
+}

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -31,7 +31,8 @@ void ConVars_Initialize()
 	mvm_showhealth = CreateConVar("mvm_showhealth", "0", "When set to 1, shows a floating health icon over enemy players.");
 	mvm_spawn_protection = CreateConVar("mvm_spawn_protection", "1", "When set to 1, players are granted ubercharge while they leave their spawn.");
 	mvm_enable_music = CreateConVar("mvm_enable_music", "1", "When set to 1, Mann vs. Machine music will play at the start and end of a round.");
-	mvm_nerf_upgrades = CreateConVar("mvm_nerf_upgrades", "1", "When set to 1, some upgrades will be modified to be fairer in player versus player modes.");
+	mvm_gas_explode_damage_modifier = CreateConVar("mvm_gas_explode_damage_modifier", "0.5", "Multiplier to damage of the explosion created by the Gas Passer's 'Explode On Ignite' upgrade.");
+	mvm_medigun_shield_damage_modifier = CreateConVar("mvm_medigun_shield_damage_modifier", "0", "Multiplier to damage of the shield created by the Medi Gun's 'Projectile Shield' upgrade.");
 	mvm_custom_upgrades_file = CreateConVar("mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
 	
 	// Always keep this hook active

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -23,7 +23,8 @@ void ConVars_Initialize()
 	mvm_currency_rewards_player_killed = CreateConVar("mvm_currency_rewards_player_killed", "15", "The fixed number of credits dropped by players on death.");
 	mvm_currency_rewards_player_count_bonus = CreateConVar("mvm_currency_rewards_player_count_bonus", "2.0", "Multiplier to dropped currency that gradually increases up to this value until all player slots have been filled.", _, true, 1.0);
 	mvm_currency_rewards_player_catchup_max = CreateConVar("mvm_currency_rewards_player_catchup_max", "1.5", "Maximum currency bonus multiplier for losing teams.", _, true, 1.0);
-	mvm_currency_rewards_bonus_arena = CreateConVar("mvm_currency_rewards_bonus_arena", "2.0", "Multiplier to dropped currency in arena mode.", _, true, 1.0);
+	mvm_currency_rewards_player_modifier_arena = CreateConVar("mvm_currency_rewards_player_modifier_arena", "2.0", "Multiplier to dropped currency in arena mode.");
+	mvm_currency_rewards_player_modifier_medieval = CreateConVar("mvm_currency_rewards_player_modifier_medieval", "0.33", "Multiplier to dropped currency in medieval mode.");
 	mvm_currency_hud_position_x = CreateConVar("mvm_currency_hud_position_x", "-1", "x coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
 	mvm_currency_hud_position_y = CreateConVar("mvm_currency_hud_position_y", "0.75", "y coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
 	mvm_upgrades_reset_mode = CreateConVar("mvm_upgrades_reset_mode", "0", "How player upgrades and credits are reset after a full round has been played. 0 = Reset if teams are being switched or scrambled. 1 = Always reset. 2 = Never reset.");

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -64,11 +64,6 @@ public void ConVarChanged_Enable(ConVar convar, const char[] oldValue, const cha
 
 public void ConVarChanged_ShowHealth(ConVar convar, const char[] oldValue, const char[] newValue)
 {
-	if (!g_IsEnabled)
-	{
-		return;
-	}
-	
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client))
@@ -87,11 +82,6 @@ public void ConVarChanged_ShowHealth(ConVar convar, const char[] oldValue, const
 
 public void ConVarChanged_CustomUpgradesFile(ConVar convar, const char[] oldValue, const char[] newValue)
 {
-	if (!g_IsEnabled)
-	{
-		return;
-	}
-	
 	if (newValue[0] != '\0')
 	{
 		SetCustomUpgradesFile(newValue);
@@ -104,11 +94,6 @@ public void ConVarChanged_CustomUpgradesFile(ConVar convar, const char[] oldValu
 
 public void ConVarChanged_StartingCurrency(ConVar convar, const char[] oldValue, const char[] newValue)
 {
-	if (!g_IsEnabled)
-	{
-		return;
-	}
-	
 	// Add or remove currency from players.
 	// This might leave the player at negative currency to compensate for purchased upgrades.
 	int oldCurrency = StringToInt(oldValue);

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -37,7 +37,7 @@ static DynamicHook g_DHookCheckRespawnWaves;
 
 // Detour state
 static RoundState g_PreHookRoundState;
-static TFTeam g_PreHookTeam;	// NOTE: For clients, use the MvMPlayer methodmap
+static TFTeam g_PreHookTeam;	// For clients, use the MvMPlayer methodmap
 
 void DHooks_Initialize(GameData gamedata)
 {
@@ -45,35 +45,35 @@ void DHooks_Initialize(GameData gamedata)
 	g_DynamicHookIds = new ArrayList();
 	
 	// Create detours
-	DHooks_CreateDynamicDetour(gamedata, "CUpgrades::ApplyUpgradeToItem", DHookCallback_ApplyUpgradeToItem_Pre, DHookCallback_ApplyUpgradeToItem_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CPopulationManager::Update", DHookCallback_PopulationManagerUpdate_Pre, _);
-	DHooks_CreateDynamicDetour(gamedata, "CPopulationManager::ResetMap", DHookCallback_PopulationManagerResetMap_Pre, DHookCallback_PopulationManagerResetMap_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CPopulationManager::RemovePlayerAndItemUpgradesFromHistory", DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Pre, DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CCaptureFlag::Capture", DHookCallback_Capture_Pre, DHookCallback_Capture_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFGameRules::IsQuickBuildTime", DHookCallback_IsQuickBuildTime_Pre, DHookCallback_IsQuickBuildTime_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFGameRules::GameModeUsesUpgrades", _, DHookCallback_GameModeUsesUpgrades_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFGameRules::CanPlayerUseRespec", DHookCallback_CanPlayerUseRespec_Pre, DHookCallback_CanPlayerUseRespec_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFGameRules::DistributeCurrencyAmount", DHookCallback_DistributeCurrencyAmount_Pre, DHookCallback_DistributeCurrencyAmount_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFPlayerShared::ConditionGameRulesThink", DHookCallback_ConditionGameRulesThink_Pre, DHookCallback_ConditionGameRulesThink_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFPlayerShared::CanRecieveMedigunChargeEffect", DHookCallback_CanRecieveMedigunChargeEffect_Pre, DHookCallback_CanRecieveMedigunChargeEffect_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFPlayerShared::RadiusSpyScan", DHookCallback_RadiusSpyScan_Pre, DHookCallback_RadiusSpyScan_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFPlayer::RemoveAllOwnedEntitiesFromWorld", DHookCallback_RemoveAllOwnedEntitiesFromWorld_Pre, DHookCallback_RemoveAllOwnedEntitiesFromWorld_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFPlayer::CanBuild", DHookCallback_CanBuild_Pre, DHookCallback_CanBuild_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFPlayer::ManageRegularWeapons", DHookCallback_ManageRegularWeapons_Pre, DHookCallback_ManageRegularWeapons_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CTFPlayer::RegenThink", DHookCallback_RegenThink_Pre, DHookCallback_RegenThink_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CBaseObject::FindSnapToBuildPos", DHookCallback_FindSnapToBuildPos_Pre, DHookCallback_FindSnapToBuildPos_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CBaseObject::ShouldQuickBuild", DHookCallback_ShouldQuickBuild_Pre, DHookCallback_ShouldQuickBuild_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CObjectSapper::ApplyRoboSapperEffects", DHookCallback_ApplyRoboSapperEffects_Pre, DHookCallback_ApplyRoboSapperEffects_Post);
-	DHooks_CreateDynamicDetour(gamedata, "CRegenerateZone::Regenerate", DHookCallback_Regenerate_Pre, _);
+	DHooks_AddDynamicDetour(gamedata, "CUpgrades::ApplyUpgradeToItem", DHookCallback_ApplyUpgradeToItem_Pre, DHookCallback_ApplyUpgradeToItem_Post);
+	DHooks_AddDynamicDetour(gamedata, "CPopulationManager::Update", DHookCallback_PopulationManagerUpdate_Pre, _);
+	DHooks_AddDynamicDetour(gamedata, "CPopulationManager::ResetMap", DHookCallback_PopulationManagerResetMap_Pre, DHookCallback_PopulationManagerResetMap_Post);
+	DHooks_AddDynamicDetour(gamedata, "CPopulationManager::RemovePlayerAndItemUpgradesFromHistory", DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Pre, DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Post);
+	DHooks_AddDynamicDetour(gamedata, "CCaptureFlag::Capture", DHookCallback_Capture_Pre, DHookCallback_Capture_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFGameRules::IsQuickBuildTime", DHookCallback_IsQuickBuildTime_Pre, DHookCallback_IsQuickBuildTime_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFGameRules::GameModeUsesUpgrades", _, DHookCallback_GameModeUsesUpgrades_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFGameRules::CanPlayerUseRespec", DHookCallback_CanPlayerUseRespec_Pre, DHookCallback_CanPlayerUseRespec_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFGameRules::DistributeCurrencyAmount", DHookCallback_DistributeCurrencyAmount_Pre, DHookCallback_DistributeCurrencyAmount_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFPlayerShared::ConditionGameRulesThink", DHookCallback_ConditionGameRulesThink_Pre, DHookCallback_ConditionGameRulesThink_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFPlayerShared::CanRecieveMedigunChargeEffect", DHookCallback_CanRecieveMedigunChargeEffect_Pre, DHookCallback_CanRecieveMedigunChargeEffect_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFPlayerShared::RadiusSpyScan", DHookCallback_RadiusSpyScan_Pre, DHookCallback_RadiusSpyScan_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFPlayer::RemoveAllOwnedEntitiesFromWorld", DHookCallback_RemoveAllOwnedEntitiesFromWorld_Pre, DHookCallback_RemoveAllOwnedEntitiesFromWorld_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFPlayer::CanBuild", DHookCallback_CanBuild_Pre, DHookCallback_CanBuild_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFPlayer::ManageRegularWeapons", DHookCallback_ManageRegularWeapons_Pre, DHookCallback_ManageRegularWeapons_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFPlayer::RegenThink", DHookCallback_RegenThink_Pre, DHookCallback_RegenThink_Post);
+	DHooks_AddDynamicDetour(gamedata, "CBaseObject::FindSnapToBuildPos", DHookCallback_FindSnapToBuildPos_Pre, DHookCallback_FindSnapToBuildPos_Post);
+	DHooks_AddDynamicDetour(gamedata, "CBaseObject::ShouldQuickBuild", DHookCallback_ShouldQuickBuild_Pre, DHookCallback_ShouldQuickBuild_Post);
+	DHooks_AddDynamicDetour(gamedata, "CObjectSapper::ApplyRoboSapperEffects", DHookCallback_ApplyRoboSapperEffects_Pre, DHookCallback_ApplyRoboSapperEffects_Post);
+	DHooks_AddDynamicDetour(gamedata, "CRegenerateZone::Regenerate", DHookCallback_Regenerate_Pre, _);
 	
 	// Create virtual hooks
-	g_DHookMyTouch = DHooks_CreateDynamicHook(gamedata, "CCurrencyPack::MyTouch");
-	g_DHookComeToRest = DHooks_CreateDynamicHook(gamedata, "CCurrencyPack::ComeToRest");
-	g_DHookValidTouch = DHooks_CreateDynamicHook(gamedata, "CTFPowerup::ValidTouch");
-	g_DHookSetWinningTeam = DHooks_CreateDynamicHook(gamedata, "CTFGameRules::SetWinningTeam");
-	g_DHookShouldRespawnQuickly = DHooks_CreateDynamicHook(gamedata, "CTFGameRules::ShouldRespawnQuickly");
-	g_DHookRoundRespawn = DHooks_CreateDynamicHook(gamedata, "CTFGameRules::RoundRespawn");
-	g_DHookCheckRespawnWaves = DHooks_CreateDynamicHook(gamedata, "CTFGameRules::CheckRespawnWaves");
+	g_DHookMyTouch = DHooks_AddDynamicHook(gamedata, "CCurrencyPack::MyTouch");
+	g_DHookComeToRest = DHooks_AddDynamicHook(gamedata, "CCurrencyPack::ComeToRest");
+	g_DHookValidTouch = DHooks_AddDynamicHook(gamedata, "CTFPowerup::ValidTouch");
+	g_DHookSetWinningTeam = DHooks_AddDynamicHook(gamedata, "CTFGameRules::SetWinningTeam");
+	g_DHookShouldRespawnQuickly = DHooks_AddDynamicHook(gamedata, "CTFGameRules::ShouldRespawnQuickly");
+	g_DHookRoundRespawn = DHooks_AddDynamicHook(gamedata, "CTFGameRules::RoundRespawn");
+	g_DHookCheckRespawnWaves = DHooks_AddDynamicHook(gamedata, "CTFGameRules::CheckRespawnWaves");
 }
 
 void DHooks_Toggle(bool enable)
@@ -175,7 +175,7 @@ void DHooks_OnEntityCreated(int entity, const char[] classname)
 	}
 }
 
-static void DHooks_CreateDynamicDetour(GameData gamedata, const char[] name, DHookCallback callbackPre = INVALID_FUNCTION, DHookCallback callbackPost = INVALID_FUNCTION)
+static void DHooks_AddDynamicDetour(GameData gamedata, const char[] name, DHookCallback callbackPre = INVALID_FUNCTION, DHookCallback callbackPost = INVALID_FUNCTION)
 {
 	DynamicDetour detour = DynamicDetour.FromConf(gamedata, name);
 	if (detour)
@@ -193,7 +193,7 @@ static void DHooks_CreateDynamicDetour(GameData gamedata, const char[] name, DHo
 	}
 }
 
-static DynamicHook DHooks_CreateDynamicHook(GameData gamedata, const char[] name)
+static DynamicHook DHooks_AddDynamicHook(GameData gamedata, const char[] name)
 {
 	DynamicHook hook = DynamicHook.FromConf(gamedata, name);
 	if (!hook)
@@ -648,7 +648,7 @@ public MRESReturn DHookCallback_Regenerate_Pre(int regenerate, DHookParam params
 
 public MRESReturn DHookCallback_MyTouch_Pre(int currencypack, DHookReturn ret, DHookParam params)
 {
-	// NOTE: You cannot substitute this virtual hook with an SDKHook because the Touch function for CItem is actually CItem::ItemTouch, NOT CItem::MyTouch.
+	// This virtual hook cannot be substituted with an SDKHook because the Touch function for CItem is actually CItem::ItemTouch, not CItem::MyTouch.
 	// CItem::ItemTouch simply calls CItem::MyTouch and deletes the entity if it returns true, which causes a TouchPost SDKHook to never get called.
 	
 	int player = params.Get(1);
@@ -713,7 +713,7 @@ public MRESReturn DHookCallback_ValidTouch_Post(int currencypack, DHookReturn re
 
 public MRESReturn DHookCallback_SetWinningTeam_Post(DHookParam params)
 {
-	// NOTE: This logic can not be moved to a teamplay_round_win event hook.
+	// This logic can not be moved to a teamplay_round_win event hook.
 	// Team scramble logic runs AFTER it fires, meaning CTFGameRules::ShouldScrambleTeams would always return false.
 	
 	bool forceMapReset = params.Get(3);
@@ -752,8 +752,8 @@ public MRESReturn DHookCallback_ShouldRespawnQuickly_Post(DHookReturn ret, DHook
 
 public MRESReturn DHookCallback_RoundRespawn_Pre()
 {
-	// NOTE: This logic can not be moved to a teamplay_round_start event hook.
-	// CPopulationManager::ResetMap NEEDS to be called right before CTFGameRules::RoundRespawn for the upgrade reset to work properly.
+	// This logic cannot be moved to a teamplay_round_start event hook.
+	// CPopulationManager::ResetMap needs to be called right before CTFGameRules::RoundRespawn for the upgrade reset to work properly.
 	
 	// Switch team credits if the teams are being switched
 	if (SDKCall_ShouldSwitchTeams())
@@ -783,7 +783,7 @@ public MRESReturn DHookCallback_RoundRespawn_Pre()
 				{
 					int spentCurrency = SDKCall_GetPlayerCurrencySpent(populator, client);
 					SDKCall_AddPlayerCurrencySpent(populator, client, -spentCurrency);
-					MvMPlayer(client).Currency = g_StartingCurrency;
+					MvMPlayer(client).Currency = mvm_currency_starting.IntValue;
 					MvMPlayer(client).AcquiredCredits = 0;
 				}
 			}

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -81,7 +81,7 @@ void DHooks_Toggle(bool enable)
 	for (int i = 0; i < g_DynamicDetours.Length; i++)
 	{
 		DetourData data;
-		if (g_DynamicDetours.GetArray(i, data) > 0)
+		if (g_DynamicDetours.GetArray(i, data))
 		{
 			if (data.callbackPre != INVALID_FUNCTION)
 			{

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -117,13 +117,11 @@ void DHooks_Toggle(bool enable)
 	else
 	{
 		// Remove virtual hooks
-		for (int i = 0; i < g_DynamicHookIds.Length; i++)
+		for (int i = g_DynamicHookIds.Length - 1; i >= 0; i--)
 		{
 			int hookid = g_DynamicHookIds.Get(i);
 			DynamicHook.RemoveHook(hookid);
 		}
-		
-		g_DynamicHookIds.Clear();
 	}
 }
 

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -50,7 +50,7 @@ void Events_Toggle(bool enable)
 	for (int i = 0; i < g_Events.Length; i++)
 	{
 		EventData data;
-		if (g_Events.GetArray(i, data) > 0)
+		if (g_Events.GetArray(i, data))
 		{
 			if (enable)
 			{
@@ -225,7 +225,7 @@ public void Event_PlayerDeath(Event event, const char[] name, bool dontBroadcast
 	bool silent_kill = event.GetBool("silent_kill");
 	
 	int dropAmount = CalculateCurrencyAmount(attacker);
-	if (dropAmount > 0)
+	if (dropAmount)
 	{
 		// Enable MvM for CTFGameRules::DistributeCurrencyAmount to properly distribute the currency
 		SetMannVsMachineMode(true);

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -190,7 +190,9 @@ public void Event_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
 {
 	// Never do this for mass-switches as it may lead to buffer overflows
 	if (SDKCall_ShouldSwitchTeams() || SDKCall_ShouldScrambleTeams())
+	{
 		return;
+	}
 	
 	int client = GetClientOfUserId(event.GetInt("userid"));
 	TFTeam team = view_as<TFTeam>(event.GetInt("team"));

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -207,7 +207,7 @@ public void Event_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
 		if (populator != -1)
 		{
 			// This should put us at the right currency, given that we've removed item and player upgrade tracking by this point
-			int totalAcquiredCurrency = MvMTeam(team).AcquiredCredits + MvMPlayer(client).AcquiredCredits + g_StartingCurrency;
+			int totalAcquiredCurrency = MvMTeam(team).AcquiredCredits + MvMPlayer(client).AcquiredCredits + mvm_currency_starting.IntValue;
 			int spentCurrency = SDKCall_GetPlayerCurrencySpent(populator, client);
 			MvMPlayer(client).Currency = totalAcquiredCurrency - spentCurrency;
 		}

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -112,7 +112,7 @@ void SetCustomUpgradesFile(const char[] path)
 			Format(downloadPath, sizeof(downloadPath), "download/%s", path);
 			GameRules_SetPropString("m_pszCustomUpgradesFile", downloadPath);
 			
-			// Tell the client the upgrades file has changed
+			// Notify the client that the upgrades file has changed
 			Event event = CreateEvent("upgrades_file_changed");
 			if (event)
 			{

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -127,6 +127,23 @@ void SetCustomUpgradesFile(const char[] path)
 	}
 }
 
+void ClearCustomUpgradesFile()
+{
+	char customUpgradesFile[PLATFORM_MAX_PATH];
+	GameRules_GetPropString("m_pszCustomUpgradesFile", customUpgradesFile, sizeof(customUpgradesFile));
+	
+	// Reset to the default upgrades file
+	if (strcmp(customUpgradesFile, DEFAULT_UPGRADES_FILE))
+	{
+		int gamerules = FindEntityByClassname(MaxClients + 1, "tf_gamerules");
+		if (gamerules != -1)
+		{
+			SetVariantString(DEFAULT_UPGRADES_FILE);
+			AcceptEntityInput(gamerules, "SetCustomUpgradesFile");
+		}
+	}
+}
+
 bool IsMannVsMachineMode()
 {
 	return view_as<bool>(GameRules_GetProp("m_bPlayingMannVsMachine"));

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -191,8 +191,8 @@ int CalculateCurrencyAmount(int attacker)
 	if (IsValidClient(attacker))
 	{
 		// Award bonus credits to losing teams
-		float redMultiplier = MvMTeam(TFTeam_Red).AcquiredCredits > 0 ? float(MvMTeam(TFTeam_Blue).AcquiredCredits) / float(MvMTeam(TFTeam_Red).AcquiredCredits) : 1.0;
-		float blueMultiplier = MvMTeam(TFTeam_Blue).AcquiredCredits > 0 ? float(MvMTeam(TFTeam_Red).AcquiredCredits) / float(MvMTeam(TFTeam_Blue).AcquiredCredits) : 1.0;
+		float redMultiplier = MvMTeam(TFTeam_Red).AcquiredCredits ? float(MvMTeam(TFTeam_Blue).AcquiredCredits) / float(MvMTeam(TFTeam_Red).AcquiredCredits) : 1.0;
+		float blueMultiplier = MvMTeam(TFTeam_Blue).AcquiredCredits ? float(MvMTeam(TFTeam_Red).AcquiredCredits) / float(MvMTeam(TFTeam_Blue).AcquiredCredits) : 1.0;
 		
 		// Clamp it so it doesn't reach into insanity
 		redMultiplier = Clamp(redMultiplier, 1.0, mvm_currency_rewards_player_catchup_max.FloatValue);

--- a/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
+++ b/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
@@ -187,4 +187,10 @@ methodmap MvMTeam
 			g_TeamWorldMoney[this._teamNum] = value;
 		}
 	}
+	
+	public void Reset()
+	{
+		this.AcquiredCredits = 0;
+		this.WorldMoney = 0;
+	}
 }

--- a/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
+++ b/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
@@ -145,6 +145,7 @@ methodmap MvMPlayer
 		this.HasPurchasedUpgrades = false;
 		this.IsClosingUpgradeMenu = false;
 		this.AcquiredCredits = 0;
+		this.Currency = mvm_currency_starting.IntValue;
 	}
 }
 

--- a/addons/sourcemod/scripting/mannvsmann/patches.sp
+++ b/addons/sourcemod/scripting/mannvsmann/patches.sp
@@ -21,7 +21,7 @@ void Patches_Initialize(GameData gamedata)
 {
 	g_MemoryPatches = new ArrayList();
 	
-	Patches_CreateMemoryPatch(gamedata, "MemoryPatch_RadiusCurrencyCollectionCheck");
+	Patches_AddMemoryPatch(gamedata, "MemoryPatch_RadiusCurrencyCollectionCheck");
 }
 
 void Patches_Toggle(bool enable)
@@ -43,7 +43,7 @@ void Patches_Toggle(bool enable)
 	}
 }
 
-static void Patches_CreateMemoryPatch(GameData gamedata, const char[] name)
+static void Patches_AddMemoryPatch(GameData gamedata, const char[] name)
 {
 	MemoryPatch patch = new MemoryPatch(name, gamedata);
 	if (patch)

--- a/addons/sourcemod/scripting/mannvsmann/patches.sp
+++ b/addons/sourcemod/scripting/mannvsmann/patches.sp
@@ -15,28 +15,43 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-static MemoryPatch g_MemoryPatchRadiusCurrencyCollectionCheck;
+static ArrayList g_MemoryPatches;
 
 void Patches_Initialize(GameData gamedata)
 {
-	MemoryPatch.SetGameData(gamedata);
+	g_MemoryPatches = new ArrayList();
 	
-	// Allows players not on RED to collect credits in a radius.
-	// This is not done with a DHook because of nested function calls that depend on the proper team.
-	CreateMemoryPatch(g_MemoryPatchRadiusCurrencyCollectionCheck, "MemoryPatch_RadiusCurrencyCollectionCheck");
+	Patches_CreateMemoryPatch(gamedata, "MemoryPatch_RadiusCurrencyCollectionCheck");
 }
 
-void Patches_Destroy()
+void Patches_Toggle(bool enable)
 {
-	if (g_MemoryPatchRadiusCurrencyCollectionCheck)
-		g_MemoryPatchRadiusCurrencyCollectionCheck.Disable();
+	for (int i = 0; i < g_MemoryPatches.Length; i++)
+	{
+		MemoryPatch patch = g_MemoryPatches.Get(i);
+		if (patch)
+		{
+			if (enable)
+			{
+				patch.Enable();
+			}
+			else
+			{
+				patch.Disable();
+			}
+		}
+	}
 }
 
-static void CreateMemoryPatch(MemoryPatch &patch, const char[] name)
+static void Patches_CreateMemoryPatch(GameData gamedata, const char[] name)
 {
-	patch = new MemoryPatch(name);
+	MemoryPatch patch = new MemoryPatch(name, gamedata);
 	if (patch)
-		patch.Enable();
+	{
+		g_MemoryPatches.Push(patch);
+	}
 	else
+	{
 		LogError("Failed to create memory patch %s", name);
+	}
 }

--- a/addons/sourcemod/scripting/mannvsmann/sdkcalls.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkcalls.sp
@@ -46,19 +46,21 @@ void SDKCalls_Initialize(GameData gamedata)
 	g_SDKCallGetNextRespawnWave = PrepSDKCall_GetNextRespawnWave(gamedata);
 }
 
-Handle PrepSDKCall_ResetMap(GameData gamedata)
+static Handle PrepSDKCall_ResetMap(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Entity);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CPopulationManager::ResetMap");
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CPopulationManager::ResetMap");
+	{
+		LogMessage("Failed to create SDKCall: CPopulationManager::ResetMap");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_GetPlayerCurrencySpent(GameData gamedata)
+static Handle PrepSDKCall_GetPlayerCurrencySpent(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Entity);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CPopulationManager::GetPlayerCurrencySpent");
@@ -67,12 +69,14 @@ Handle PrepSDKCall_GetPlayerCurrencySpent(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CPopulationManager::GetPlayerCurrencySpent");
+	{
+		LogMessage("Failed to create SDKCall: CPopulationManager::GetPlayerCurrencySpent");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_AddPlayerCurrencySpent(GameData gamedata)
+static Handle PrepSDKCall_AddPlayerCurrencySpent(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Entity);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CPopulationManager::AddPlayerCurrencySpent");
@@ -81,12 +85,14 @@ Handle PrepSDKCall_AddPlayerCurrencySpent(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CPopulationManager::AddPlayerCurrencySpent");
+	{
+		LogMessage("Failed to create SDKCall: CPopulationManager::AddPlayerCurrencySpent");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_DropCurrencyPack(GameData gamedata)
+static Handle PrepSDKCall_DropCurrencyPack(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Player);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CTFPlayer::DropCurrencyPack");
@@ -97,12 +103,14 @@ Handle PrepSDKCall_DropCurrencyPack(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CTFPlayer::DropCurrencyPack");
+	{
+		LogMessage("Failed to create SDKCall: CTFPlayer::DropCurrencyPack");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_GetEquippedWearableForLoadoutSlot(GameData gamedata)
+static Handle PrepSDKCall_GetEquippedWearableForLoadoutSlot(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Player);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CTFPlayer::GetEquippedWearableForLoadoutSlot");
@@ -111,12 +119,14 @@ Handle PrepSDKCall_GetEquippedWearableForLoadoutSlot(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CTFPlayer::GetEquippedWearableForLoadoutSlot");
+	{
+		LogMessage("Failed to create SDKCall: CTFPlayer::GetEquippedWearableForLoadoutSlot");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_CanRecieveMedigunChargeEffect(GameData gamedata)
+static Handle PrepSDKCall_CanRecieveMedigunChargeEffect(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Raw);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CTFPlayerShared::CanRecieveMedigunChargeEffect");
@@ -125,12 +135,14 @@ Handle PrepSDKCall_CanRecieveMedigunChargeEffect(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CTFPlayerShared::CanRecieveMedigunChargeEffect");
+	{
+		LogMessage("Failed to create SDKCall: CTFPlayerShared::CanRecieveMedigunChargeEffect");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_ReviveMarkerCreate(GameData gamedata)
+static Handle PrepSDKCall_ReviveMarkerCreate(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CTFReviveMarker::Create");
@@ -139,12 +151,14 @@ Handle PrepSDKCall_ReviveMarkerCreate(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CTFReviveMarker::Create");
+	{
+		LogMessage("Failed to create SDKCall: CTFReviveMarker::Create");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_RemoveImmediate(GameData gamedata)
+static Handle PrepSDKCall_RemoveImmediate(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "UTIL_RemoveImmediate");
@@ -152,12 +166,14 @@ Handle PrepSDKCall_RemoveImmediate(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: UTIL_RemoveImmediate");
+	{
+		LogMessage("Failed to create SDKCall: UTIL_RemoveImmediate");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_DistributeCurrencyAmount(GameData gamedata)
+static Handle PrepSDKCall_DistributeCurrencyAmount(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_GameRules);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CTFGameRules::DistributeCurrencyAmount");
@@ -170,12 +186,14 @@ Handle PrepSDKCall_DistributeCurrencyAmount(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CTFGameRules::DistributeCurrencyAmount");
+	{
+		LogMessage("Failed to create SDKCall: CTFGameRules::DistributeCurrencyAmount");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_GetBaseEntity(GameData gamedata)
+static Handle PrepSDKCall_GetBaseEntity(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_Raw);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Virtual, "CBaseEntity::GetBaseEntity");
@@ -183,12 +201,14 @@ Handle PrepSDKCall_GetBaseEntity(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CBaseEntity::GetBaseEntity");
+	{
+		LogMessage("Failed to create SDKCall: CBaseEntity::GetBaseEntity");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_ShouldSwitchTeams(GameData gamedata)
+static Handle PrepSDKCall_ShouldSwitchTeams(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_GameRules);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Virtual, "CTFGameRules::ShouldSwitchTeams");
@@ -196,12 +216,14 @@ Handle PrepSDKCall_ShouldSwitchTeams(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CTFGameRules::ShouldSwitchTeams");
+	{
+		LogMessage("Failed to create SDKCall: CTFGameRules::ShouldSwitchTeams");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_ShouldScrambleTeams(GameData gamedata)
+static Handle PrepSDKCall_ShouldScrambleTeams(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_GameRules);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Virtual, "CTFGameRules::ShouldScrambleTeams");
@@ -209,12 +231,14 @@ Handle PrepSDKCall_ShouldScrambleTeams(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CTFGameRules::ShouldScrambleTeams");
+	{
+		LogMessage("Failed to create SDKCall: CTFGameRules::ShouldScrambleTeams");
+	}
 	
 	return call;
 }
 
-Handle PrepSDKCall_GetNextRespawnWave(GameData gamedata)
+static Handle PrepSDKCall_GetNextRespawnWave(GameData gamedata)
 {
 	StartPrepSDKCall(SDKCall_GameRules);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Virtual, "CTFGameRules::GetNextRespawnWave");
@@ -224,7 +248,9 @@ Handle PrepSDKCall_GetNextRespawnWave(GameData gamedata)
 	
 	Handle call = EndPrepSDKCall();
 	if (!call)
-		LogMessage("Failed to create SDK call: CTFGameRules::GetNextRespawnWave");
+	{
+		LogMessage("Failed to create SDKCall: CTFGameRules::GetNextRespawnWave");
+	}
 	
 	return call;
 }
@@ -238,7 +264,9 @@ void SDKCall_ResetMap(int populator)
 int SDKCall_GetPlayerCurrencySpent(int populator, int player)
 {
 	if (g_SDKCallGetPlayerCurrencySpent)
+	{
 		return SDKCall(g_SDKCallGetPlayerCurrencySpent, populator, player);
+	}
 	
 	return 0;
 }
@@ -246,19 +274,25 @@ int SDKCall_GetPlayerCurrencySpent(int populator, int player)
 void SDKCall_AddPlayerCurrencySpent(int populator, int player, int cost)
 {
 	if (g_SDKCallAddPlayerCurrencySpent)
+	{
 		SDKCall(g_SDKCallAddPlayerCurrencySpent, populator, player, cost);
+	}
 }
 
 void SDKCall_DropCurrencyPack(int player, CurrencyRewards size = TF_CURRENCY_PACK_SMALL, int amount = 0, bool forceDistribute = false, int moneyMaker = -1)
 {
 	if (g_SDKCallDropCurrencyPack)
+	{
 		SDKCall(g_SDKCallDropCurrencyPack, player, size, amount, forceDistribute, moneyMaker);
+	}
 }
 
 int SDKCall_GetEquippedWearableForLoadoutSlot(int player, int loadoutSlot)
 {
 	if (g_SDKCallGetEquippedWearableForLoadoutSlot)
+	{
 		return SDKCall(g_SDKCallGetEquippedWearableForLoadoutSlot, player, loadoutSlot);
+	}
 	
 	return -1;
 }
@@ -266,7 +300,9 @@ int SDKCall_GetEquippedWearableForLoadoutSlot(int player, int loadoutSlot)
 bool SDKCall_CanRecieveMedigunChargeEffect(Address playerShared, MedigunChargeType type)
 {
 	if (g_SDKCallCanRecieveMedigunChargeEffect)
+	{
 		return SDKCall(g_SDKCallCanRecieveMedigunChargeEffect, playerShared, type);
+	}
 	
 	return false;
 }
@@ -274,7 +310,9 @@ bool SDKCall_CanRecieveMedigunChargeEffect(Address playerShared, MedigunChargeTy
 int SDKCall_ReviveMarkerCreate(int owner)
 {
 	if (g_SDKCallReviveMarkerCreate)
+	{
 		return SDKCall(g_SDKCallReviveMarkerCreate, owner);
+	}
 	
 	return -1;
 }
@@ -282,13 +320,17 @@ int SDKCall_ReviveMarkerCreate(int owner)
 void SDKCall_RemoveImmediate(int entity)
 {
 	if (g_SDKCallRemoveImmediate)
+	{
 		SDKCall(g_SDKCallRemoveImmediate, entity);
+	}
 }
 
 int SDKCall_DistributeCurrencyAmount(int amount, int player = -1, bool shared = true, bool countAsDropped = false, bool isBonus = false)
 {
 	if (g_SDKCallDistributeCurrencyAmount)
+	{
 		return SDKCall(g_SDKCallDistributeCurrencyAmount, amount, player, shared, countAsDropped, isBonus);
+	}
 	
 	return 0;
 }
@@ -296,7 +338,9 @@ int SDKCall_DistributeCurrencyAmount(int amount, int player = -1, bool shared = 
 int SDKCall_GetBaseEntity(Address address)
 {
 	if (g_SDKCallGetBaseEntity)
+	{
 		return SDKCall(g_SDKCallGetBaseEntity, address);
+	}
 	
 	return -1;
 }
@@ -304,7 +348,9 @@ int SDKCall_GetBaseEntity(Address address)
 bool SDKCall_ShouldSwitchTeams()
 {
 	if (g_SDKCallShouldSwitchTeams)
+	{
 		return SDKCall(g_SDKCallShouldSwitchTeams);
+	}
 	
 	return false;
 }
@@ -312,7 +358,9 @@ bool SDKCall_ShouldSwitchTeams()
 bool SDKCall_ShouldScrambleTeams()
 {
 	if (g_SDKCallShouldScrambleTeams)
+	{
 		return SDKCall(g_SDKCallShouldScrambleTeams);
+	}
 	
 	return false;
 }
@@ -320,7 +368,9 @@ bool SDKCall_ShouldScrambleTeams()
 float SDKCall_GetNextRespawnWave(TFTeam team, int player)
 {
 	if (g_SDKCallGetNextRespawnWave)
+	{
 		return SDKCall(g_SDKCallGetNextRespawnWave, team, player);
+	}
 	
 	return 0.0;
 }

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -93,28 +93,28 @@ public Action SDKHookCB_Client_OnTakeDamageAlive(int victim, int &attacker, int 
 	// Blast resistance also applies to self-inflicted damage in MvM
 	SetMannVsMachineMode(true);
 	
-	if (mvm_nerf_upgrades.BoolValue)
+	if (weapon != -1)
 	{
+		// Modify the damage of the Gas Passer's 'Explode On Ignite' upgrade
 		char classname[32];
-		if (weapon != -1 && GetEntityClassname(weapon, classname, sizeof(classname)))
+		if (GetEntityClassname(weapon, classname, sizeof(classname)) && !strcmp(classname, "tf_weapon_jar_gas"))
 		{
-			// Allow blast resistance to reduce the damage of the Gas Passer 'Explode On Ignite' upgrade
-			if (!strcmp(classname, "tf_weapon_jar_gas") && damagetype & DMG_SLASH)
+			if (damagetype & DMG_SLASH)
 			{
-				damage = 250.0;
-				damagetype |= DMG_BLAST;
+				damage *= mvm_gas_explode_damage_modifier.FloatValue;
 				return Plugin_Changed;
 			}
 		}
-		
-		if (inflictor != -1 && GetEntityClassname(inflictor, classname, sizeof(classname)))
+	}
+	
+	if (inflictor != -1)
+	{
+		// Modify the damage of the Medi Gun's 'Projectile Shield' upgrade
+		char classname[32];
+		if (GetEntityClassname(inflictor, classname, sizeof(classname)) && !strcmp(classname, "entity_medigun_shield"))
 		{
-			// Do not allow the Medigun's 'Projectile Shield' upgrade to deal damage
-			if (!strcmp(classname, "entity_medigun_shield"))
-			{
-				damage = 0.0;
-				return Plugin_Changed;
-			}
+			damage *= mvm_medigun_shield_damage_modifier.FloatValue;
+			return Plugin_Changed;
 		}
 	}
 	
@@ -140,7 +140,9 @@ public Action SDKHookCB_ReviveMarker_SetTransmit(int marker, int client)
 {
 	// Only transmit revive markers to our own team and spectators
 	if (TF2_GetClientTeam(client) != TFTeam_Spectator && TF2_GetTeam(marker) != TF2_GetClientTeam(client))
+	{
 		return Plugin_Handled;
+	}
 	
 	return Plugin_Continue;
 }
@@ -162,7 +164,9 @@ public Action CurrencyPack_SetTransmit(int currencypack, int client)
 {
 	// Only transmit currency packs to our own team and spectators
 	if (TF2_GetClientTeam(client) != TFTeam_Spectator && TF2_GetTeam(currencypack) != TF2_GetClientTeam(client))
+	{
 		return Plugin_Handled;
+	}
 	
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -15,40 +15,66 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-void SDKHooks_HookClient(int client)
+enum struct SDKHookData
 {
-	SDKHook(client, SDKHook_OnTakeDamage, Client_OnTakeDamage);
-	SDKHook(client, SDKHook_OnTakeDamagePost, Client_OnTakeDamagePost);
-	SDKHook(client, SDKHook_OnTakeDamageAlive, Client_OnTakeDamageAlive);
-	SDKHook(client, SDKHook_OnTakeDamageAlivePost, Client_OnTakeDamageAlivePost);
+	SDKHookType type;
+	SDKHookCB callback;
 }
 
-void SDKHooks_OnEntityCreated(int entity, const char[] classname)
+void SDKHooks_HookClient(int client)
+{
+	SDKHook(client, SDKHook_OnTakeDamage, SDKHookCB_Client_OnTakeDamage);
+	SDKHook(client, SDKHook_OnTakeDamagePost, SDKHookCB_Client_OnTakeDamagePost);
+	SDKHook(client, SDKHook_OnTakeDamageAlive, SDKHookCB_Client_OnTakeDamageAlive);
+	SDKHook(client, SDKHook_OnTakeDamageAlivePost, SDKHookCB_Client_OnTakeDamageAlivePost);
+}
+
+void SDKHooks_UnhookClient(int client)
+{
+	SDKUnhook(client, SDKHook_OnTakeDamage, SDKHookCB_Client_OnTakeDamage);
+	SDKUnhook(client, SDKHook_OnTakeDamagePost, SDKHookCB_Client_OnTakeDamagePost);
+	SDKUnhook(client, SDKHook_OnTakeDamageAlive, SDKHookCB_Client_OnTakeDamageAlive);
+	SDKUnhook(client, SDKHook_OnTakeDamageAlivePost, SDKHookCB_Client_OnTakeDamageAlivePost);
+}
+
+void SDKHooks_HookEntity(int entity, const char[] classname)
 {
 	if (!strcmp(classname, "func_regenerate"))
 	{
-		SDKHook(entity, SDKHook_EndTouch, Regenerate_EndTouch);
+		SDKHook(entity, SDKHook_EndTouch, SDKHookCB_Regenerate_EndTouch);
 	}
 	else if (!strcmp(classname, "entity_revive_marker"))
 	{
-		SDKHook(entity, SDKHook_SetTransmit, ReviveMarker_SetTransmit);
+		SDKHook(entity, SDKHook_SetTransmit, SDKHookCB_ReviveMarker_SetTransmit);
 	}
 	else if (!strncmp(classname, "item_currencypack_", 18))
 	{
-		SDKHook(entity, SDKHook_SpawnPost, CurrencyPack_SpawnPost);
+		SDKHook(entity, SDKHook_SpawnPost, SDKHookCB_CurrencyPack_SpawnPost);
 	}
 	else if (!strcmp(classname, "obj_attachment_sapper"))
 	{
-		SDKHook(entity, SDKHook_Spawn, Sapper_Spawn);
-		SDKHook(entity, SDKHook_SpawnPost, Sapper_SpawnPost);
+		SDKHook(entity, SDKHook_Spawn, SDKHookCB_Sapper_Spawn);
+		SDKHook(entity, SDKHook_SpawnPost, SDKHookCB_Sapper_SpawnPost);
 	}
 	else if (!strcmp(classname, "func_respawnroom"))
 	{
-		SDKHook(entity, SDKHook_Touch, RespawnRoom_Touch);
+		SDKHook(entity, SDKHook_Touch, SDKHookCB_RespawnRoom_Touch);
 	}
 }
 
-public Action Client_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+void SDKHooks_UnhookEntity(int entity, const char[] classname)
+{
+	if (!strcmp(classname, "func_regenerate"))
+	{
+		SDKUnhook(entity, SDKHook_EndTouch, SDKHookCB_Regenerate_EndTouch);
+	}
+	else if (!strcmp(classname, "func_respawnroom"))
+	{
+		SDKUnhook(entity, SDKHook_Touch, SDKHookCB_RespawnRoom_Touch);
+	}
+}
+
+public Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
 	// OnTakeDamage may get called while CTFPlayerShared::ConditionGameRulesThink has MvM enabled.
 	// This causes unwanted things like defender death sounds and additional revive markers to appear, so we suppress it.
@@ -57,12 +83,12 @@ public Action Client_OnTakeDamage(int victim, int &attacker, int &inflictor, flo
 	return Plugin_Continue;
 }
 
-public void Client_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
+public void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
 {
 	ResetMannVsMachineMode();
 }
 
-public Action Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action SDKHookCB_Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
 	// Blast resistance also applies to self-inflicted damage in MvM
 	SetMannVsMachineMode(true);
@@ -95,12 +121,12 @@ public Action Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor
 	return Plugin_Continue;
 }
 
-public void Client_OnTakeDamageAlivePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
+public void SDKHookCB_Client_OnTakeDamageAlivePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
 {
 	ResetMannVsMachineMode();
 }
 
-public Action Regenerate_EndTouch(int regenerate, int other)
+public Action SDKHookCB_Regenerate_EndTouch(int regenerate, int other)
 {
 	if (IsValidClient(other))
 	{
@@ -110,7 +136,7 @@ public Action Regenerate_EndTouch(int regenerate, int other)
 	return Plugin_Continue;
 }
 
-public Action ReviveMarker_SetTransmit(int marker, int client)
+public Action SDKHookCB_ReviveMarker_SetTransmit(int marker, int client)
 {
 	// Only transmit revive markers to our own team and spectators
 	if (TF2_GetClientTeam(client) != TFTeam_Spectator && TF2_GetTeam(marker) != TF2_GetClientTeam(client))
@@ -119,7 +145,7 @@ public Action ReviveMarker_SetTransmit(int marker, int client)
 	return Plugin_Continue;
 }
 
-public void CurrencyPack_SpawnPost(int currencypack)
+public void SDKHookCB_CurrencyPack_SpawnPost(int currencypack)
 {
 	// Add the currency value to the world money
 	if (!GetEntProp(currencypack, Prop_Send, "m_bDistributed"))
@@ -141,18 +167,18 @@ public Action CurrencyPack_SetTransmit(int currencypack, int client)
 	return Plugin_Continue;
 }
 
-public void Sapper_Spawn(int sapper)
+public void SDKHookCB_Sapper_Spawn(int sapper)
 {
 	// Prevents repeat placement of sappers on players
 	SetMannVsMachineMode(true);
 }
 
-public void Sapper_SpawnPost(int sapper)
+public void SDKHookCB_Sapper_SpawnPost(int sapper)
 {
 	ResetMannVsMachineMode();
 }
 
-public Action RespawnRoom_Touch(int respawnroom, int other)
+public Action SDKHookCB_RespawnRoom_Touch(int respawnroom, int other)
 {
 	if (!IsInArenaMode() && mvm_spawn_protection.BoolValue && GameRules_GetRoundState() != RoundState_TeamWin)
 	{

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -37,7 +37,7 @@ void SDKHooks_UnhookClient(int client)
 	SDKUnhook(client, SDKHook_OnTakeDamageAlivePost, SDKHookCB_Client_OnTakeDamageAlivePost);
 }
 
-void SDKHooks_HookEntity(int entity, const char[] classname)
+void SDKHooks_OnEntityCreated(int entity, const char[] classname)
 {
 	if (!strcmp(classname, "func_regenerate"))
 	{

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -15,12 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-enum struct SDKHookData
-{
-	SDKHookType type;
-	SDKHookCB callback;
-}
-
 void SDKHooks_HookClient(int client)
 {
 	SDKHook(client, SDKHook_OnTakeDamage, SDKHookCB_Client_OnTakeDamage);


### PR DESCRIPTION
Quite a few changes here, mostly refactoring old code and adding a plugin toggle convar.

* Major code cleanup across all files
    * Updated code formatting to be consistent
    * Updated function names to be consistent
    * Moved ConVar-related code to a new file
* Added a plugin toggle mechanism
    * Controlled by new convar: `mvm_enable` (def. `1`)
* Starting currency may now be changed mid-game
    * Player currency will be updated accordingly