### PR TITLE
Release 1.7.0

### DIFF
--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -172,6 +172,7 @@ ConVar mvm_enable_music;
 ConVar mvm_gas_explode_damage_modifier;
 ConVar mvm_medigun_shield_damage_modifier;
 ConVar mvm_radius_spy_scan;
+ConVar mvm_revive_markers;
 ConVar mvm_custom_upgrades_file;
 
 // DHooks

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -194,6 +194,7 @@ bool g_ForceMapReset;
 
 #include "mannvsmann/methodmaps.sp"
 
+#include "mannvsmann/commands.sp"
 #include "mannvsmann/convars.sp"
 #include "mannvsmann/dhooks.sp"
 #include "mannvsmann/events.sp"
@@ -219,6 +220,7 @@ public void OnPluginStart()
 	g_CurrencyHudSync = CreateHudSynchronizer();
 	g_BuybackHudSync = CreateHudSynchronizer();
 	
+	Commands_Initialize();
 	ConVars_Initialize();
 	Events_Initialize();
 	

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -173,6 +173,7 @@ ConVar mvm_gas_explode_damage_modifier;
 ConVar mvm_medigun_shield_damage_modifier;
 ConVar mvm_radius_spy_scan;
 ConVar mvm_revive_markers;
+ConVar mvm_broadcast_events;
 ConVar mvm_custom_upgrades_file;
 
 // DHooks
@@ -785,7 +786,7 @@ public Action Timer_UpdateHudText(Handle timer)
 					ShowSyncHudText(client, g_CurrencyHudSync, "$%d ($%d)", MvMPlayer(client).Currency, MvMTeam(team).WorldMoney);
 				}
 			}
-			else if (team == TFTeam_Spectator)
+			else if (IsClientObserver(client))
 			{
 				// Spectators can see currency stats for each team
 				SetHudTextParams(mvm_currency_hud_position_x.FloatValue, mvm_currency_hud_position_y.FloatValue, 0.1, 122, 196, 55, 255);

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -26,7 +26,7 @@
 #include <tf2attributes>
 #include <memorypatch>
 
-#define PLUGIN_VERSION	"1.6.1"
+#define PLUGIN_VERSION	"1.7.0"
 
 #define DEFAULT_UPGRADES_FILE	"scripts/items/mvm_upgrades.txt"
 

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -349,7 +349,20 @@ public void OnEntityDestroyed(int entity)
 			if (!GetEntProp(entity, Prop_Send, "m_bDistributed"))
 			{
 				TFTeam team = TF2_GetTeam(entity);
-				MvMTeam(team).WorldMoney -= GetEntData(entity, g_OffsetCurrencyPackAmount);
+				int amount = GetEntData(entity, g_OffsetCurrencyPackAmount);
+				
+				if (team == TFTeam_Unassigned)
+				{
+					// If it's a neutral currency pack, remove it from world money for all teams
+					for (TFTeam i = TFTeam_Unassigned; i <= TFTeam_Blue; i++)
+					{
+						MvMTeam(i).WorldMoney -= amount;
+					}
+				}
+				else
+				{
+					MvMTeam(team).WorldMoney -= amount;
+				}
 			}
 		}
 		else if (!strcmp(classname, "func_regenerate"))
@@ -696,7 +709,7 @@ public Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sam
 				for (int i = 0; i < numClients; i++)
 				{
 					int client = clients[i];
-					if (TF2_GetClientTeam(client) != TF2_GetTeam(entity) && TF2_GetClientTeam(client) != TFTeam_Spectator)
+					if (!IsEntVisibleToClient(entity, client))
 					{
 						for (int j = i; j < numClients - 1; j++)
 						{

--- a/addons/sourcemod/scripting/mannvsmann/commands.sp
+++ b/addons/sourcemod/scripting/mannvsmann/commands.sp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2021  Mikusch
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+void Commands_Initialize()
+{
+	RegAdminCmd("sm_currency_give", ConCmd_GiveCurrency, ADMFLAG_CHEATS, "Have some in-game money.");
+}
+
+public Action ConCmd_GiveCurrency(int client, int args)
+{
+	if (!g_IsEnabled)
+	{
+		return Plugin_Continue;
+	}
+	
+	if (args < 2)
+	{
+		ReplyToCommand(client, "[SM] Usage: sm_currency_give <#userid|name> <amount>");
+		return Plugin_Handled;
+	}
+	
+	char arg1[MAX_TARGET_LENGTH], arg2[16];
+	GetCmdArg(1, arg1, sizeof(arg1));
+	GetCmdArg(2, arg2, sizeof(arg2));
+	
+	int amount = 0;
+	if (StringToIntEx(arg2, amount) == 0 || amount == 0)
+	{
+		ReplyToCommand(client, "[SM] %t", "Invalid Amount");
+		return Plugin_Handled;
+	}
+	
+	char target_name[MAX_TARGET_LENGTH];
+	int target_list[MAXPLAYERS], target_count;
+	bool tn_is_ml;
+	
+	if ((target_count = ProcessTargetString(arg1, client, target_list, MaxClients + 1, COMMAND_FILTER_NO_IMMUNITY, target_name, sizeof(target_name), tn_is_ml)) <= 0)
+	{
+		ReplyToTargetError(client, target_count);
+		return Plugin_Handled;
+	}
+	
+	for (int i = 0; i < target_count; i++)
+	{
+		int target = target_list[i];
+		MvMPlayer(target).Currency += amount;
+	}
+	
+	char fmtAmount[16];
+	FormatCurrencyAmount(amount, fmtAmount, sizeof(fmtAmount));
+	
+	if (tn_is_ml)
+	{
+		ShowActivity2(client, "[SM] ", "%t", "MvM_CurrencyAdded", fmtAmount, target_name);
+	}
+	else
+	{
+		ShowActivity2(client, "[SM] ", "%t", "MvM_CurrencyAdded", fmtAmount, "_s", target_name);
+	}
+	
+	return Plugin_Handled;
+}

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -35,6 +35,7 @@ void ConVars_Initialize()
 	mvm_medigun_shield_damage_modifier = CreateConVar("mvm_medigun_shield_damage_modifier", "0", "Multiplier to damage of the shield created by the Medi Gun's 'Projectile Shield' upgrade.");
 	mvm_radius_spy_scan = CreateConVar("mvm_radius_spy_scan", "1", "When set to 1, Spies will reveal cloaked enemy Spies in a radius.");
 	mvm_revive_markers = CreateConVar("mvm_revive_markers", "1", "When set to 1, players will create revive markers on death.");
+	mvm_broadcast_events = CreateConVar("mvm_broadcast_events", "0", "When set to 1, player buyback and powerup bottle events will be broadcast to all players.");
 	mvm_custom_upgrades_file = CreateConVar("mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
 	
 	// Always keep this hook active

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -34,6 +34,7 @@ void ConVars_Initialize()
 	mvm_gas_explode_damage_modifier = CreateConVar("mvm_gas_explode_damage_modifier", "0.5", "Multiplier to damage of the explosion created by the Gas Passer's 'Explode On Ignite' upgrade.");
 	mvm_medigun_shield_damage_modifier = CreateConVar("mvm_medigun_shield_damage_modifier", "0", "Multiplier to damage of the shield created by the Medi Gun's 'Projectile Shield' upgrade.");
 	mvm_radius_spy_scan = CreateConVar("mvm_radius_spy_scan", "1", "When set to 1, Spies will reveal cloaked enemy Spies in a radius.");
+	mvm_revive_markers = CreateConVar("mvm_revive_markers", "1", "When set to 1, players will create revive markers on death.");
 	mvm_custom_upgrades_file = CreateConVar("mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
 	
 	// Always keep this hook active

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -35,7 +35,7 @@ void ConVars_Initialize()
 	mvm_medigun_shield_damage_modifier = CreateConVar("mvm_medigun_shield_damage_modifier", "0", "Multiplier to damage of the shield created by the Medi Gun's 'Projectile Shield' upgrade.");
 	mvm_radius_spy_scan = CreateConVar("mvm_radius_spy_scan", "1", "When set to 1, Spies will reveal cloaked enemy Spies in a radius.");
 	mvm_revive_markers = CreateConVar("mvm_revive_markers", "1", "When set to 1, players will create revive markers on death.");
-	mvm_broadcast_events = CreateConVar("mvm_broadcast_events", "0", "When set to 1, player buyback and powerup bottle events will be broadcast to all players.");
+	mvm_broadcast_events = CreateConVar("mvm_broadcast_events", "0", "When set to 1, the 'player_buyback' and 'player_used_powerup_bottle' events will be broadcast to all players.");
 	mvm_custom_upgrades_file = CreateConVar("mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
 	
 	// Always keep this hook active

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -798,8 +798,10 @@ public MRESReturn DHookCallback_RoundRespawn_Pre()
 			g_ForceMapReset = false;
 			
 			// Reset accumulated team credits on a full reset
-			MvMTeam(TFTeam_Red).AcquiredCredits = 0;
-			MvMTeam(TFTeam_Blue).AcquiredCredits = 0;
+			for (TFTeam team = TFTeam_Unassigned; team <= TFTeam_Blue; team++)
+			{
+				MvMTeam(team).AcquiredCredits = 0;
+			}
 			
 			// Reset currency for all clients
 			for (int client = 1; client <= MaxClients; client++)

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -314,6 +314,11 @@ public void EventHook_PlayerChangeClass(Event event, const char[] name, bool don
 
 public Action EventHook_PlayerBuyback(Event event, const char[] name, bool dontBroadcast)
 {
+	if (mvm_broadcast_events.BoolValue)
+	{
+		return Plugin_Continue;
+	}
+	
 	int player = event.GetInt("player");
 	
 	// Only broadcast to spectators and our own team
@@ -321,7 +326,7 @@ public Action EventHook_PlayerBuyback(Event event, const char[] name, bool dontB
 	
 	for (int client = 1; client <= MaxClients; client++)
 	{
-		if (IsClientInGame(client) && (TF2_GetClientTeam(client) == TF2_GetClientTeam(player) || TF2_GetClientTeam(client) == TFTeam_Spectator))
+		if (IsClientInGame(client) && (TF2_GetClientTeam(client) <= TFTeam_Spectator || TF2_GetClientTeam(client) == TF2_GetClientTeam(player)))
 		{
 			event.FireToClient(client);
 		}
@@ -332,6 +337,11 @@ public Action EventHook_PlayerBuyback(Event event, const char[] name, bool dontB
 
 public Action EventHook_PlayerUsedPowerupBottle(Event event, const char[] name, bool dontBroadcast)
 {
+	if (mvm_broadcast_events.BoolValue)
+	{
+		return Plugin_Continue;
+	}
+	
 	int player = event.GetInt("player");
 	
 	// Only broadcast to spectators and our own team
@@ -339,7 +349,7 @@ public Action EventHook_PlayerUsedPowerupBottle(Event event, const char[] name, 
 	
 	for (int client = 1; client <= MaxClients; client++)
 	{
-		if (IsClientInGame(client) && (TF2_GetClientTeam(client) == TF2_GetClientTeam(player) || TF2_GetClientTeam(client) == TFTeam_Spectator))
+		if (IsClientInGame(client) && (TF2_GetClientTeam(client) <= TFTeam_Spectator || TF2_GetClientTeam(client) == TF2_GetClientTeam(player)))
 		{
 			event.FireToClient(client);
 		}

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -262,7 +262,7 @@ public void EventHook_PlayerDeath(Event event, const char[] name, bool dontBroad
 		ResetMannVsMachineMode();
 	}
 	
-	if (!IsInArenaMode())
+	if (!IsInArenaMode() && mvm_revive_markers.BoolValue)
 	{
 		if (!(death_flags & TF_DEATHFLAG_DEADRINGER) && !silent_kill)
 		{

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -243,3 +243,15 @@ int CalculateCurrencyAmount(int attacker)
 	
 	return RoundToCeil(amount);
 }
+
+int FormatCurrencyAmount(int amount, char[] buffer, int maxlength)
+{
+	if (amount < 0)
+	{
+		return Format(buffer, maxlength, "-$%d", -amount);
+	}
+	else
+	{
+		return Format(buffer, maxlength, "$%d", amount);
+	}
+}

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -162,6 +162,18 @@ void ResetMannVsMachineMode()
 	GameRules_SetProp("m_bPlayingMannVsMachine", g_IsMannVsMachineModeState[index]);
 }
 
+bool IsEntVisibleToClient(int entity, int client)
+{
+	// Always show neutral entities and allow spectators to see everything 
+	if (TF2_GetTeam(entity) == TFTeam_Unassigned || TF2_GetClientTeam(client) <= TFTeam_Spectator)
+	{
+		return true;
+	}
+	
+	// Only visible when on the same team
+	return TF2_GetTeam(entity) == TF2_GetClientTeam(client);
+}
+
 bool IsInArenaMode()
 {
 	return view_as<TFGameType>(GameRules_GetProp("m_nGameType")) == TF_GAMETYPE_ARENA;

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -187,6 +187,11 @@ int CalculateCurrencyAmount(int attacker)
 	// Base currency amount
 	float amount = mvm_currency_rewards_player_killed.FloatValue;
 	
+	if (!amount)
+	{
+		return 0;
+	}
+	
 	// If we have an attacker, use their team to determine whether to award a catchup bonus
 	if (IsValidClient(attacker))
 	{

--- a/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
+++ b/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
@@ -89,7 +89,7 @@ methodmap MvMPlayer
 		}
 		public set(int value)
 		{
-			SetEntProp(this._client, Prop_Send, "m_nCurrency", value);
+			SetEntProp(this._client, Prop_Send, "m_nCurrency", Clamp(value, 0, 30000));
 		}
 	}
 	

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -133,7 +133,7 @@ public Action SDKHookCB_Regenerate_EndTouch(int regenerate, int other)
 public Action SDKHookCB_ReviveMarker_SetTransmit(int marker, int client)
 {
 	// Only transmit revive markers to our own team and spectators
-	if (TF2_GetClientTeam(client) != TFTeam_Spectator && TF2_GetTeam(marker) != TF2_GetClientTeam(client))
+	if (!IsEntVisibleToClient(marker, client))
 	{
 		return Plugin_Handled;
 	}
@@ -147,7 +147,20 @@ public void SDKHookCB_CurrencyPack_SpawnPost(int currencypack)
 	if (!GetEntProp(currencypack, Prop_Send, "m_bDistributed"))
 	{
 		TFTeam team = TF2_GetTeam(currencypack);
-		MvMTeam(team).WorldMoney += GetEntData(currencypack, g_OffsetCurrencyPackAmount);
+		int amount = GetEntData(currencypack, g_OffsetCurrencyPackAmount);
+		
+		if (team == TFTeam_Unassigned)
+		{
+			// If it's a neutral currency pack, add it to world money for all teams
+			for (TFTeam i = TFTeam_Unassigned; i <= TFTeam_Blue; i++)
+			{
+				MvMTeam(i).WorldMoney += amount;
+			}
+		}
+		else
+		{
+			MvMTeam(team).WorldMoney += amount;
+		}
 	}
 	
 	SetEdictFlags(currencypack, (GetEdictFlags(currencypack) & ~FL_EDICT_ALWAYS));
@@ -157,7 +170,7 @@ public void SDKHookCB_CurrencyPack_SpawnPost(int currencypack)
 public Action CurrencyPack_SetTransmit(int currencypack, int client)
 {
 	// Only transmit currency packs to our own team and spectators
-	if (TF2_GetClientTeam(client) != TFTeam_Spectator && TF2_GetTeam(currencypack) != TF2_GetClientTeam(client))
+	if (!IsEntVisibleToClient(currencypack, client))
 	{
 		return Plugin_Handled;
 	}

--- a/addons/sourcemod/translations/mannvsmann.phrases.txt
+++ b/addons/sourcemod/translations/mannvsmann.phrases.txt
@@ -32,6 +32,11 @@
 		"en"		"Use the 'build 2' console command ('%%build 2%%') to build a Disposable Sentry Gun."
 		"ru"		"Используйте консольную команду 'build 2' ('%%build 2%%'), чтобы построить одноразовую турель."
 	}
+	"MvM_CurrencyAdded"
+	{
+		"#format"	"{1:s},{2:t}"
+		"en"		"Added {1} to {2}."
+	}
 	"MvM_UpgradeStation"
 	{
 		"en"		"Upgrade Station"


### PR DESCRIPTION
* Added 2 new convars
    * `mvm_revive_markers` (def. `1`) - When set to 1, players will create revive markers on death.
    * `mvm_broadcast_events` (def. `0`) - When set to 1, the 'player_buyback' and 'player_used_powerup_bottle' events will be broadcast to all players.
* Added the `sm_currency_give` command
    * Functions identical to the built-in `currency_give` command with added SourceMod targeting
    * Usage: `sm_currency_give <#userid|name> <amount>`
* Added support for neutral (unassigned) currency packs
    * Neutral currency packs may be collected by both teams
    * Neutral currency packs can be created by destroying tanks or spawning them using console commands
* Performance and code quality improvements