### PR TITLE
Add utility cvars and make use of attribute hooks

### DIFF
--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -156,6 +156,23 @@ enum
 	RESET_MODE_NEVER,
 };
 
+char g_PlayerClassNames[][] =
+{
+	"Undefined",
+	"Scout",
+	"Sniper",
+	"Soldier",
+	"Demoman",
+	"Medic",
+	"Heavy",
+	"Pyro",
+	"Spy",
+	"Engineer",
+	"Civilian",
+	"",
+	"Random"
+};
+
 // ConVars
 ConVar mvm_enable;
 ConVar mvm_currency_starting;
@@ -180,6 +197,7 @@ ConVar mvm_radius_spy_scan;
 ConVar mvm_revive_markers;
 ConVar mvm_broadcast_events;
 ConVar mvm_custom_upgrades_file;
+ConVar mvm_death_responses;
 
 // DHooks
 TFTeam g_CurrencyPackTeam = TFTeam_Invalid;

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -343,10 +343,9 @@ public void OnEntityCreated(int entity, const char[] classname)
 		// Do not allow dropped weapons, as you can sell their upgrades for free currency
 		RemoveEntity(entity);
 	}
-	
-	if (g_IsMapRunning && IsInArenaMode())
+	else if (!strcmp(classname, "tf_powerup_bottle"))
 	{
-		if (!strcmp(classname, "tf_powerup_bottle"))
+		if (g_IsMapRunning && IsInArenaMode())
 		{
 			// Canteens can't be activated in arena mode, so just remove any powerup bottles
 			RemoveEntity(entity);
@@ -469,8 +468,7 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				// Tell Engineers how to build disposable sentries
 				if (TF2_GetPlayerClass(client) == TFClass_Engineer)
 				{
-					int melee = GetPlayerWeaponSlot(client, 3);
-					if (melee != -1 && TF2Attrib_GetByName(melee, "engy disposable sentries"))
+					if (TF2Attrib_HookValueInt(0, "engy_disposable_sentries", client))
 					{
 						PrintHintText(client, "%t", "MvM_Upgrade_DisposableSentry");
 					}
@@ -523,8 +521,8 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				else if (!SDKCall_CanRecieveMedigunChargeEffect(GetPlayerShared(client), MEDIGUN_CHARGE_INVULN))
 				{
 					// Do not allow players to use ubercharge canteens if they are also unable to receive medigun charge effects
-					int powerupBottle = SDKCall_GetEquippedWearableForLoadoutSlot(client, view_as<int>(LOADOUT_POSITION_ACTION));
-					if (powerupBottle != -1 && TF2Attrib_GetByName(powerupBottle, "ubercharge"))
+					int powerupBottle = SDKCall_GetEquippedWearableForLoadoutSlot(client, LOADOUT_POSITION_ACTION);
+					if (powerupBottle != -1 && TF2Attrib_HookValueInt(0, "ubercharge", powerupBottle))
 					{
 						ResetMannVsMachineMode();
 						return Plugin_Handled;
@@ -533,8 +531,12 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 			}
 			else
 			{
-				PrintCenterText(client, "%t", "MvM_Hint_CannotUseCanteens");
-				return Plugin_Handled;
+				int powerupBottle = SDKCall_GetEquippedWearableForLoadoutSlot(client, LOADOUT_POSITION_ACTION);
+				if (powerupBottle != -1 && TF2Attrib_HookValueInt(0, "powerup_charges", powerupBottle))
+				{
+					PrintCenterText(client, "%t", "MvM_Hint_CannotUseCanteens");
+					return Plugin_Handled;
+				}
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -682,7 +682,7 @@ void TogglePlugin(bool enable)
 	}
 }
 
-public Action EntityOutput_OnTimer10SecRemain(const char[] output, int caller, int activator, float delay)
+static Action EntityOutput_OnTimer10SecRemain(const char[] output, int caller, int activator, float delay)
 {
 	if (mvm_enable_music.BoolValue)
 	{
@@ -700,7 +700,7 @@ public Action EntityOutput_OnTimer10SecRemain(const char[] output, int caller, i
 	return Plugin_Continue;
 }
 
-public Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &entity, int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
+static Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &entity, int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
 {
 	Action action = Plugin_Continue;
 	
@@ -734,7 +734,7 @@ public Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sam
 	return action;
 }
 
-public Action Timer_UpdateHudText(Handle timer)
+static Action Timer_UpdateHudText(Handle timer)
 {
 	if (!g_IsEnabled)
 	{
@@ -803,7 +803,7 @@ public Action Timer_UpdateHudText(Handle timer)
 	return Plugin_Continue;
 }
 
-public int MenuHandler_UpgradeRespec(Menu menu, MenuAction action, int param1, int param2)
+static int MenuHandler_UpgradeRespec(Menu menu, MenuAction action, int param1, int param2)
 {
 	switch (action)
 	{

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -164,6 +164,8 @@ ConVar mvm_currency_rewards_player_catchup_min;
 ConVar mvm_currency_rewards_player_catchup_max;
 ConVar mvm_currency_rewards_player_modifier_arena;
 ConVar mvm_currency_rewards_player_modifier_medieval;
+ConVar mvm_currency_hud_player;
+ConVar mvm_currency_hud_spectator;
 ConVar mvm_currency_hud_position_x;
 ConVar mvm_currency_hud_position_y;
 ConVar mvm_upgrades_reset_mode;
@@ -783,13 +785,13 @@ public Action Timer_UpdateHudText(Handle timer)
 				}
 				
 				// Show players how much currency they have outside of upgrade stations
-				if (!GetEntProp(client, Prop_Send, "m_bInUpgradeZone"))
+				if (!GetEntProp(client, Prop_Send, "m_bInUpgradeZone") && mvm_currency_hud_player.BoolValue)
 				{
 					SetHudTextParams(mvm_currency_hud_position_x.FloatValue, mvm_currency_hud_position_y.FloatValue, 0.1, 122, 196, 55, 255);
 					ShowSyncHudText(client, g_CurrencyHudSync, "$%d ($%d)", MvMPlayer(client).Currency, MvMTeam(team).WorldMoney);
 				}
 			}
-			else if (IsClientObserver(client))
+			else if (IsClientObserver(client) && mvm_currency_hud_spectator.BoolValue)
 			{
 				// Spectators can see currency stats for each team
 				SetHudTextParams(mvm_currency_hud_position_x.FloatValue, mvm_currency_hud_position_y.FloatValue, 0.1, 122, 196, 55, 255);

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -35,6 +35,7 @@
 #define MVM_BUYBACK_COST_PER_SEC	5
 
 const TFTeam TFTeam_Invalid = view_as<TFTeam>(-1);
+const TFTeam TFTeam_Any = view_as<TFTeam>(-2);
 
 enum CurrencyRewards
 {
@@ -168,6 +169,7 @@ ConVar mvm_currency_hud_player;
 ConVar mvm_currency_hud_spectator;
 ConVar mvm_currency_hud_position_x;
 ConVar mvm_currency_hud_position_y;
+ConVar mvm_upgrades_team_restriction;
 ConVar mvm_upgrades_reset_mode;
 ConVar mvm_showhealth;
 ConVar mvm_spawn_protection;

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -26,7 +26,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.8.1"
+#define PLUGIN_VERSION	"1.9.0"
 
 #define DEFAULT_UPGRADES_FILE	"scripts/items/mvm_upgrades.txt"
 

--- a/addons/sourcemod/scripting/mannvsmann/commands.sp
+++ b/addons/sourcemod/scripting/mannvsmann/commands.sp
@@ -23,7 +23,7 @@ void Commands_Initialize()
 	RegAdminCmd("sm_currency_give", ConCmd_GiveCurrency, ADMFLAG_CHEATS, "Have some in-game money.");
 }
 
-public Action ConCmd_GiveCurrency(int client, int args)
+static Action ConCmd_GiveCurrency(int client, int args)
 {
 	if (!g_IsEnabled)
 	{

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -44,6 +44,7 @@ void ConVars_Initialize()
 	mvm_revive_markers = CreateConVar("mvm_revive_markers", "1", "When set to 1, players will create revive markers on death.");
 	mvm_broadcast_events = CreateConVar("mvm_broadcast_events", "0", "When set to 1, the 'player_buyback' and 'player_used_powerup_bottle' events will be broadcast to all players.");
 	mvm_custom_upgrades_file = CreateConVar("mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
+	mvm_death_responses = CreateConVar("mvm_death_responses", "0", "When set to 1, players will announce their teammate's deaths.");
 	
 	// Always keep this hook active
 	mvm_enable.AddChangeHook(ConVarChanged_Enable);

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -64,7 +64,7 @@ void ConVars_Toggle(bool enable)
 	}
 }
 
-public void ConVarChanged_Enable(ConVar convar, const char[] oldValue, const char[] newValue)
+static void ConVarChanged_Enable(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	if (g_IsEnabled != convar.BoolValue)
 	{
@@ -72,7 +72,7 @@ public void ConVarChanged_Enable(ConVar convar, const char[] oldValue, const cha
 	}
 }
 
-public void ConVarChanged_ShowHealth(ConVar convar, const char[] oldValue, const char[] newValue)
+static void ConVarChanged_ShowHealth(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	for (int client = 1; client <= MaxClients; client++)
 	{
@@ -90,7 +90,7 @@ public void ConVarChanged_ShowHealth(ConVar convar, const char[] oldValue, const
 	}
 }
 
-public void ConVarChanged_CustomUpgradesFile(ConVar convar, const char[] oldValue, const char[] newValue)
+static void ConVarChanged_CustomUpgradesFile(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	if (newValue[0] != EOS)
 	{
@@ -102,7 +102,7 @@ public void ConVarChanged_CustomUpgradesFile(ConVar convar, const char[] oldValu
 	}
 }
 
-public void ConVarChanged_StartingCurrency(ConVar convar, const char[] oldValue, const char[] newValue)
+static void ConVarChanged_StartingCurrency(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	// Add or remove currency from players.
 	// This might leave the player at negative currency to compensate for purchased upgrades.

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -29,6 +29,8 @@ void ConVars_Initialize()
 	mvm_currency_rewards_player_catchup_max = CreateConVar("mvm_currency_rewards_player_catchup_max", "1.5", "Maximum currency bonus multiplier for losing teams.", _, true, 1.0);
 	mvm_currency_rewards_player_modifier_arena = CreateConVar("mvm_currency_rewards_player_modifier_arena", "2.0", "Multiplier to dropped currency in arena mode.");
 	mvm_currency_rewards_player_modifier_medieval = CreateConVar("mvm_currency_rewards_player_modifier_medieval", "0.33", "Multiplier to dropped currency in medieval mode.");
+	mvm_currency_hud_player = CreateConVar("mvm_currency_hud_player", "1", "When set to 1, players will be shown their credits outside of upgrade stations.");
+	mvm_currency_hud_spectator = CreateConVar("mvm_currency_hud_spectator", "1", "When set to 1, spectators will be shown the credit values of each team.");
 	mvm_currency_hud_position_x = CreateConVar("mvm_currency_hud_position_x", "-1", "x coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
 	mvm_currency_hud_position_y = CreateConVar("mvm_currency_hud_position_y", "0.75", "y coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
 	mvm_upgrades_reset_mode = CreateConVar("mvm_upgrades_reset_mode", "0", "How player upgrades and credits are reset after a full round has been played. 0 = Reset if teams are being switched or scrambled. 1 = Always reset. 2 = Never reset.");

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -33,7 +33,6 @@ void ConVars_Initialize()
 	mvm_currency_hud_spectator = CreateConVar("mvm_currency_hud_spectator", "1", "When set to 1, spectators will be shown the credit values of each team.");
 	mvm_currency_hud_position_x = CreateConVar("mvm_currency_hud_position_x", "-1", "x coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
 	mvm_currency_hud_position_y = CreateConVar("mvm_currency_hud_position_y", "0.75", "y coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
-	mvm_upgrades_team_restriction = CreateConVar("mvm_upgrades_team_restriction", "any", "Determines which team is allowed to to purchase upgrades.");
 	mvm_upgrades_reset_mode = CreateConVar("mvm_upgrades_reset_mode", "0", "How player upgrades and credits are reset after a full round has been played. 0 = Reset if teams are being switched or scrambled. 1 = Always reset. 2 = Never reset.");
 	mvm_showhealth = CreateConVar("mvm_showhealth", "0", "When set to 1, shows a floating health icon over enemy players.");
 	mvm_spawn_protection = CreateConVar("mvm_spawn_protection", "1", "When set to 1, players are granted ubercharge while they leave their spawn.");
@@ -45,6 +44,7 @@ void ConVars_Initialize()
 	mvm_broadcast_events = CreateConVar("mvm_broadcast_events", "0", "When set to 1, the 'player_buyback' and 'player_used_powerup_bottle' events will be broadcast to all players.");
 	mvm_custom_upgrades_file = CreateConVar("mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
 	mvm_death_responses = CreateConVar("mvm_death_responses", "0", "When set to 1, players will announce their teammate's deaths.");
+	mvm_defender_team = CreateConVar("mvm_defender_team", "any", "Determines which team is allowed to use Mann vs. Machine Defender mechanics. {any, blue, red, spectator}");
 	
 	// Always keep this hook active
 	mvm_enable.AddChangeHook(ConVarChanged_Enable);

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -33,6 +33,7 @@ void ConVars_Initialize()
 	mvm_currency_hud_spectator = CreateConVar("mvm_currency_hud_spectator", "1", "When set to 1, spectators will be shown the credit values of each team.");
 	mvm_currency_hud_position_x = CreateConVar("mvm_currency_hud_position_x", "-1", "x coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
 	mvm_currency_hud_position_y = CreateConVar("mvm_currency_hud_position_y", "0.75", "y coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
+	mvm_upgrades_team_restriction = CreateConVar("mvm_upgrades_team_restriction", "any", "Determines which team is allowed to to purchase upgrades.");
 	mvm_upgrades_reset_mode = CreateConVar("mvm_upgrades_reset_mode", "0", "How player upgrades and credits are reset after a full round has been played. 0 = Reset if teams are being switched or scrambled. 1 = Always reset. 2 = Never reset.");
 	mvm_showhealth = CreateConVar("mvm_showhealth", "0", "When set to 1, shows a floating health icon over enemy players.");
 	mvm_spawn_protection = CreateConVar("mvm_spawn_protection", "1", "When set to 1, players are granted ubercharge while they leave their spawn.");

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -681,7 +681,14 @@ static MRESReturn DHookCallback_Regenerate_Pre(int regenerate, DHookParam params
 {
 	int player = params.Get(1);
 	
-	SetEntProp(player, Prop_Send, "m_bInUpgradeZone", true);
+	if (CanPlayerUpgrade(player))
+	{
+		SetEntProp(player, Prop_Send, "m_bInUpgradeZone", true);
+	}
+	else
+	{
+		PrintCenterText(player, "%t", "MvM_Hint_CannotUpgrade");
+	}
 	
 	return MRES_Ignored;
 }

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -681,7 +681,7 @@ static MRESReturn DHookCallback_Regenerate_Pre(int regenerate, DHookParam params
 {
 	int player = params.Get(1);
 	
-	if (IsPlayerAllowedToUpgrade(player))
+	if (IsPlayerDefender(player))
 	{
 		SetEntProp(player, Prop_Send, "m_bInUpgradeZone", true);
 	}

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -236,7 +236,7 @@ public void DHookRemovalCB_OnHookRemoved(int hookid)
 	}
 }
 
-public MRESReturn DHookCallback_ApplyUpgradeToItem_Pre(int upgradestation, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_ApplyUpgradeToItem_Pre(int upgradestation, DHookReturn ret, DHookParam params)
 {
 	// This function has some special logic for MvM that we want
 	SetMannVsMachineMode(true);
@@ -244,20 +244,20 @@ public MRESReturn DHookCallback_ApplyUpgradeToItem_Pre(int upgradestation, DHook
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ApplyUpgradeToItem_Post(int upgradestation, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_ApplyUpgradeToItem_Post(int upgradestation, DHookReturn ret, DHookParam params)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_PopulationManagerUpdate_Pre(int populator)
+static MRESReturn DHookCallback_PopulationManagerUpdate_Pre(int populator)
 {
 	// Prevents the populator from messing with the GC and allocating bots
 	return MRES_Supercede;
 }
 
-public MRESReturn DHookCallback_PopulationManagerResetMap_Pre(int populator)
+static MRESReturn DHookCallback_PopulationManagerResetMap_Pre(int populator)
 {
 	// MvM defenders get their upgrades and stats reset on map reset, move all players to the defender team
 	for (int client = 1; client <= MaxClients; client++)
@@ -271,7 +271,7 @@ public MRESReturn DHookCallback_PopulationManagerResetMap_Pre(int populator)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_PopulationManagerResetMap_Post(int populator)
+static MRESReturn DHookCallback_PopulationManagerResetMap_Post(int populator)
 {
 	for (int client = 1; client <= MaxClients; client++)
 	{
@@ -284,7 +284,7 @@ public MRESReturn DHookCallback_PopulationManagerResetMap_Post(int populator)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Pre(int populator, DHookParam params)
+static MRESReturn DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Pre(int populator, DHookParam params)
 {
 	// This function handles refunding currency and resetting upgrade history during a respec.
 	// We block this because we already handle this ourselves in the respec menu handler.
@@ -293,14 +293,14 @@ public MRESReturn DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Pre(int p
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Post(int populator, DHookParam params)
+static MRESReturn DHookCallback_RemovePlayerAndItemUpgradesFromHistory_Post(int populator, DHookParam params)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_Capture_Pre(int flag, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_Capture_Pre(int flag, DHookReturn ret, DHookParam params)
 {
 	// Grants the capturing team credits
 	SetMannVsMachineMode(true);
@@ -308,14 +308,14 @@ public MRESReturn DHookCallback_Capture_Pre(int flag, DHookReturn ret, DHookPara
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_Capture_Post(int flag, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_Capture_Post(int flag, DHookReturn ret, DHookParam params)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_IsQuickBuildTime_Pre(DHookReturn ret)
+static MRESReturn DHookCallback_IsQuickBuildTime_Pre(DHookReturn ret)
 {
 	// Allows Engineers to quickbuild during setup
 	SetMannVsMachineMode(true);
@@ -323,14 +323,14 @@ public MRESReturn DHookCallback_IsQuickBuildTime_Pre(DHookReturn ret)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_IsQuickBuildTime_Post(DHookReturn ret)
+static MRESReturn DHookCallback_IsQuickBuildTime_Post(DHookReturn ret)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_GameModeUsesUpgrades_Post(DHookReturn ret)
+static MRESReturn DHookCallback_GameModeUsesUpgrades_Post(DHookReturn ret)
 {
 	// Fixes various upgrades and enables a few MvM-related features
 	ret.Value = true;
@@ -338,7 +338,7 @@ public MRESReturn DHookCallback_GameModeUsesUpgrades_Post(DHookReturn ret)
 	return MRES_Supercede;
 }
 
-public MRESReturn DHookCallback_CanPlayerUseRespec_Pre(DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_CanPlayerUseRespec_Pre(DHookReturn ret, DHookParam params)
 {
 	// Enables respecs regardless of round state
 	g_PreHookRoundState = GameRules_GetRoundState();
@@ -347,14 +347,14 @@ public MRESReturn DHookCallback_CanPlayerUseRespec_Pre(DHookReturn ret, DHookPar
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_CanPlayerUseRespec_Post(DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_CanPlayerUseRespec_Post(DHookReturn ret, DHookParam params)
 {
 	GameRules_SetProp("m_iRoundState", g_PreHookRoundState);
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_DistributeCurrencyAmount_Pre(DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_DistributeCurrencyAmount_Pre(DHookReturn ret, DHookParam params)
 {
 	int amount = params.Get(1);
 	bool shared = params.Get(3);
@@ -399,7 +399,7 @@ public MRESReturn DHookCallback_DistributeCurrencyAmount_Pre(DHookReturn ret, DH
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_DistributeCurrencyAmount_Post(DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_DistributeCurrencyAmount_Post(DHookReturn ret, DHookParam params)
 {
 	bool shared = params.Get(3);
 	
@@ -420,7 +420,7 @@ public MRESReturn DHookCallback_DistributeCurrencyAmount_Post(DHookReturn ret, D
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ConditionGameRulesThink_Pre(Address playerShared)
+static MRESReturn DHookCallback_ConditionGameRulesThink_Pre(Address playerShared)
 {
 	// Enables radius currency collection, radius spy scan and increased rage gain during setup
 	SetMannVsMachineMode(true);
@@ -428,14 +428,14 @@ public MRESReturn DHookCallback_ConditionGameRulesThink_Pre(Address playerShared
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ConditionGameRulesThink_Post(Address playerShared)
+static MRESReturn DHookCallback_ConditionGameRulesThink_Post(Address playerShared)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_CanRecieveMedigunChargeEffect_Pre(Address playerShared, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_CanRecieveMedigunChargeEffect_Pre(Address playerShared, DHookReturn ret, DHookParam params)
 {
 	// MvM allows flag carriers to be ubered (enabled from CTFPlayerShared::ConditionGameRulesThink), but we don't want this for balance reasons
 	SetMannVsMachineMode(false);
@@ -443,14 +443,14 @@ public MRESReturn DHookCallback_CanRecieveMedigunChargeEffect_Pre(Address player
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_CanRecieveMedigunChargeEffect_Post(Address playerShared, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_CanRecieveMedigunChargeEffect_Post(Address playerShared, DHookReturn ret, DHookParam params)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RadiusSpyScan_Pre(Address playerShared)
+static MRESReturn DHookCallback_RadiusSpyScan_Pre(Address playerShared)
 {
 	int outer = GetPlayerSharedOuter(playerShared);
 	TFTeam team = TF2_GetClientTeam(outer);
@@ -488,7 +488,7 @@ public MRESReturn DHookCallback_RadiusSpyScan_Pre(Address playerShared)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RadiusSpyScan_Post(Address playerShared)
+static MRESReturn DHookCallback_RadiusSpyScan_Post(Address playerShared)
 {
 	int outer = GetPlayerSharedOuter(playerShared);
 	
@@ -509,7 +509,7 @@ public MRESReturn DHookCallback_RadiusSpyScan_Post(Address playerShared)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ApplyRocketPackStun_Pre(Address playerShared, DHookParam params)
+static MRESReturn DHookCallback_ApplyRocketPackStun_Pre(Address playerShared, DHookParam params)
 {
 	// Minibosses in MvM get slowed down instead of fully stunned
 	for (int client = 1; client <= MaxClients; client++)
@@ -523,7 +523,7 @@ public MRESReturn DHookCallback_ApplyRocketPackStun_Pre(Address playerShared, DH
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ApplyRocketPackStun_Post(Address playerShared, DHookParam params)
+static MRESReturn DHookCallback_ApplyRocketPackStun_Post(Address playerShared, DHookParam params)
 {
 	for (int client = 1; client <= MaxClients; client++)
 	{
@@ -536,7 +536,7 @@ public MRESReturn DHookCallback_ApplyRocketPackStun_Post(Address playerShared, D
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RemoveAllOwnedEntitiesFromWorld_Pre(int player, DHookParam params)
+static MRESReturn DHookCallback_RemoveAllOwnedEntitiesFromWorld_Pre(int player, DHookParam params)
 {
 	// MvM invaders are allowed to keep their buildings and we don't want that, move the player to the defender team
 	if (IsMannVsMachineMode())
@@ -547,7 +547,7 @@ public MRESReturn DHookCallback_RemoveAllOwnedEntitiesFromWorld_Pre(int player, 
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RemoveAllOwnedEntitiesFromWorld_Post(int player, DHookParam params)
+static MRESReturn DHookCallback_RemoveAllOwnedEntitiesFromWorld_Post(int player, DHookParam params)
 {
 	if (IsMannVsMachineMode())
 	{
@@ -557,7 +557,7 @@ public MRESReturn DHookCallback_RemoveAllOwnedEntitiesFromWorld_Post(int player,
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_CanBuild_Pre(int player, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_CanBuild_Pre(int player, DHookReturn ret, DHookParam params)
 {
 	// Limits the amount of sappers that can be placed on players
 	SetMannVsMachineMode(true);
@@ -565,14 +565,14 @@ public MRESReturn DHookCallback_CanBuild_Pre(int player, DHookReturn ret, DHookP
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_CanBuild_Post(int player, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_CanBuild_Post(int player, DHookReturn ret, DHookParam params)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ManageRegularWeapons_Pre(int player, DHookParam params)
+static MRESReturn DHookCallback_ManageRegularWeapons_Pre(int player, DHookParam params)
 {
 	// Allows the call to CTFPlayer::ReapplyPlayerUpgrades to happen
 	SetMannVsMachineMode(true);
@@ -580,14 +580,14 @@ public MRESReturn DHookCallback_ManageRegularWeapons_Pre(int player, DHookParam 
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ManageRegularWeapons_Post(int player, DHookParam params)
+static MRESReturn DHookCallback_ManageRegularWeapons_Post(int player, DHookParam params)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RegenThink_Pre(int player)
+static MRESReturn DHookCallback_RegenThink_Pre(int player)
 {
 	// Health regeneration has no scaling in MvM
 	SetMannVsMachineMode(true);
@@ -595,14 +595,14 @@ public MRESReturn DHookCallback_RegenThink_Pre(int player)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RegenThink_Post(int player)
+static MRESReturn DHookCallback_RegenThink_Post(int player)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_FindSnapToBuildPos_Pre(int obj, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_FindSnapToBuildPos_Pre(int obj, DHookReturn ret, DHookParam params)
 {
 	// Allows placing sappers on other players
 	SetMannVsMachineMode(true);
@@ -621,7 +621,7 @@ public MRESReturn DHookCallback_FindSnapToBuildPos_Pre(int obj, DHookReturn ret,
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_FindSnapToBuildPos_Post(int obj, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_FindSnapToBuildPos_Post(int obj, DHookReturn ret, DHookParam params)
 {
 	ResetMannVsMachineMode();
 	
@@ -638,7 +638,7 @@ public MRESReturn DHookCallback_FindSnapToBuildPos_Post(int obj, DHookReturn ret
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ShouldQuickBuild_Pre(int obj, DHookReturn ret)
+static MRESReturn DHookCallback_ShouldQuickBuild_Pre(int obj, DHookReturn ret)
 {
 	SetMannVsMachineMode(true);
 	
@@ -649,7 +649,7 @@ public MRESReturn DHookCallback_ShouldQuickBuild_Pre(int obj, DHookReturn ret)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ShouldQuickBuild_Post(int obj, DHookReturn ret)
+static MRESReturn DHookCallback_ShouldQuickBuild_Post(int obj, DHookReturn ret)
 {
 	ResetMannVsMachineMode();
 	
@@ -658,7 +658,7 @@ public MRESReturn DHookCallback_ShouldQuickBuild_Post(int obj, DHookReturn ret)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ApplyRoboSapperEffects_Pre(int sapper, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_ApplyRoboSapperEffects_Pre(int sapper, DHookReturn ret, DHookParam params)
 {
 	int target = params.Get(1);
 	
@@ -668,7 +668,7 @@ public MRESReturn DHookCallback_ApplyRoboSapperEffects_Pre(int sapper, DHookRetu
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ApplyRoboSapperEffects_Post(int sapper, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_ApplyRoboSapperEffects_Post(int sapper, DHookReturn ret, DHookParam params)
 {
 	int target = params.Get(1);
 	
@@ -677,7 +677,7 @@ public MRESReturn DHookCallback_ApplyRoboSapperEffects_Post(int sapper, DHookRet
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_Regenerate_Pre(int regenerate, DHookParam params)
+static MRESReturn DHookCallback_Regenerate_Pre(int regenerate, DHookParam params)
 {
 	int player = params.Get(1);
 	
@@ -686,7 +686,7 @@ public MRESReturn DHookCallback_Regenerate_Pre(int regenerate, DHookParam params
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_MyTouch_Pre(int currencypack, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_MyTouch_Pre(int currencypack, DHookReturn ret, DHookParam params)
 {
 	// This virtual hook cannot be substituted with an SDKHook because the Touch function for CItem is actually CItem::ItemTouch, not CItem::MyTouch.
 	// CItem::ItemTouch simply calls CItem::MyTouch and deletes the entity if it returns true, which causes a TouchPost SDKHook to never get called.
@@ -703,7 +703,7 @@ public MRESReturn DHookCallback_MyTouch_Pre(int currencypack, DHookReturn ret, D
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_MyTouch_Post(int currencypack, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_MyTouch_Post(int currencypack, DHookReturn ret, DHookParam params)
 {
 	int player = params.Get(1);
 	
@@ -715,7 +715,7 @@ public MRESReturn DHookCallback_MyTouch_Post(int currencypack, DHookReturn ret, 
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ComeToRest_Pre(int currencypack)
+static MRESReturn DHookCallback_ComeToRest_Pre(int currencypack)
 {
 	// Enable MvM for currency distribution
 	SetMannVsMachineMode(true);
@@ -726,7 +726,7 @@ public MRESReturn DHookCallback_ComeToRest_Pre(int currencypack)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ComeToRest_Post(int currencypack)
+static MRESReturn DHookCallback_ComeToRest_Post(int currencypack)
 {
 	ResetMannVsMachineMode();
 	
@@ -735,7 +735,7 @@ public MRESReturn DHookCallback_ComeToRest_Post(int currencypack)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ValidTouch_Pre(int currencypack, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_ValidTouch_Pre(int currencypack, DHookReturn ret, DHookParam params)
 {
 	// MvM invaders are not allowed to collect money.
 	// We are disabling MvM instead of swapping teams because ValidTouch also checks the player's team against the currency pack's team.
@@ -744,14 +744,14 @@ public MRESReturn DHookCallback_ValidTouch_Pre(int currencypack, DHookReturn ret
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ValidTouch_Post(int currencypack, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_ValidTouch_Post(int currencypack, DHookReturn ret, DHookParam params)
 {
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_SetWinningTeam_Post(DHookParam params)
+static MRESReturn DHookCallback_SetWinningTeam_Post(DHookParam params)
 {
 	// This logic can not be moved to a teamplay_round_win event hook.
 	// Team scramble logic runs AFTER it fires, meaning CTFGameRules::ShouldScrambleTeams would always return false.
@@ -766,7 +766,7 @@ public MRESReturn DHookCallback_SetWinningTeam_Post(DHookParam params)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ShouldRespawnQuickly_Pre(DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_ShouldRespawnQuickly_Pre(DHookReturn ret, DHookParam params)
 {
 	int player = params.Get(1);
 	
@@ -779,7 +779,7 @@ public MRESReturn DHookCallback_ShouldRespawnQuickly_Pre(DHookReturn ret, DHookP
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_ShouldRespawnQuickly_Post(DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_ShouldRespawnQuickly_Post(DHookReturn ret, DHookParam params)
 {
 	int player = params.Get(1);
 	
@@ -790,7 +790,7 @@ public MRESReturn DHookCallback_ShouldRespawnQuickly_Post(DHookReturn ret, DHook
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RoundRespawn_Pre()
+static MRESReturn DHookCallback_RoundRespawn_Pre()
 {
 	// This logic cannot be moved to a teamplay_round_start event hook.
 	// CPopulationManager::ResetMap needs to be called right before CTFGameRules::RoundRespawn for the upgrade reset to work properly.
@@ -843,7 +843,7 @@ public MRESReturn DHookCallback_RoundRespawn_Pre()
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_RoundRespawn_Post()
+static MRESReturn DHookCallback_RoundRespawn_Post()
 {
 	int populator = FindEntityByClassname(-1, "info_populator");
 	if (populator != -1)
@@ -854,14 +854,14 @@ public MRESReturn DHookCallback_RoundRespawn_Post()
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_CheckRespawnWaves_Pre()
+static MRESReturn DHookCallback_CheckRespawnWaves_Pre()
 {
 	SetMannVsMachineMode(true);
 	
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_CheckRespawnWaves_Post()
+static MRESReturn DHookCallback_CheckRespawnWaves_Post()
 {
 	ResetMannVsMachineMode();
 	

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -681,7 +681,7 @@ static MRESReturn DHookCallback_Regenerate_Pre(int regenerate, DHookParam params
 {
 	int player = params.Get(1);
 	
-	if (CanPlayerUpgrade(player))
+	if (IsPlayerAllowedToUpgrade(player))
 	{
 		SetEntProp(player, Prop_Send, "m_bInUpgradeZone", true);
 	}

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -87,7 +87,7 @@ static void Events_AddEvent(const char[] name, EventHook callback, EventHookMode
 	}
 }
 
-public Action EventHook_TeamplayBroadcastAudio(Event event, const char[] name, bool dontBroadcast)
+static Action EventHook_TeamplayBroadcastAudio(Event event, const char[] name, bool dontBroadcast)
 {
 	if (mvm_enable_music.BoolValue)
 	{
@@ -114,7 +114,7 @@ public Action EventHook_TeamplayBroadcastAudio(Event event, const char[] name, b
 	return Plugin_Continue;
 }
 
-public void EventHook_TeamplaySetupFinished(Event event, const char[] name, bool dontBroadcast)
+static void EventHook_TeamplaySetupFinished(Event event, const char[] name, bool dontBroadcast)
 {
 	int resource = FindEntityByClassname(-1, "tf_objective_resource");
 	if (resource != -1)
@@ -127,7 +127,7 @@ public void EventHook_TeamplaySetupFinished(Event event, const char[] name, bool
 	}
 }
 
-public void EventHook_TeamplayRoundStart(Event event, const char[] name, bool dontBroadcast)
+static void EventHook_TeamplayRoundStart(Event event, const char[] name, bool dontBroadcast)
 {
 	// Allow players to sell individual upgrades during setup
 	int resource = FindEntityByClassname(-1, "tf_objective_resource");
@@ -149,12 +149,12 @@ public void EventHook_TeamplayRoundStart(Event event, const char[] name, bool do
 	}
 }
 
-public void EventHook_TeamplayRestartRound(Event event, const char[] name, bool dontBroadcast)
+static void EventHook_TeamplayRestartRound(Event event, const char[] name, bool dontBroadcast)
 {
 	g_ForceMapReset = true;
 }
 
-public void EventHook_ArenaRoundStart(Event event, const char[] name, bool dontBroadcast)
+static void EventHook_ArenaRoundStart(Event event, const char[] name, bool dontBroadcast)
 {
 	for (int client = 1; client <= MaxClients; client++)
 	{
@@ -166,7 +166,7 @@ public void EventHook_ArenaRoundStart(Event event, const char[] name, bool dontB
 	}
 }
 
-public void EventHook_PostInventoryApplication(Event event, const char[] name, bool dontBroadcast)
+static void EventHook_PostInventoryApplication(Event event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(event.GetInt("userid"));
 	
@@ -177,7 +177,7 @@ public void EventHook_PostInventoryApplication(Event event, const char[] name, b
 	}
 }
 
-public void EventHook_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
+static void EventHook_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
 {
 	// Never do this for mass-switches as it may lead to buffer overflows
 	if (SDKCall_ShouldSwitchTeams() || SDKCall_ShouldScrambleTeams())
@@ -205,7 +205,7 @@ public void EventHook_PlayerTeam(Event event, const char[] name, bool dontBroadc
 	}
 }
 
-public void EventHook_PlayerDeath(Event event, const char[] name, bool dontBroadcast)
+static void EventHook_PlayerDeath(Event event, const char[] name, bool dontBroadcast)
 {
 	int victim = GetClientOfUserId(event.GetInt("userid"));
 	int inflictor = event.GetInt("inflictor_entindex");
@@ -278,7 +278,7 @@ public void EventHook_PlayerDeath(Event event, const char[] name, bool dontBroad
 	}
 }
 
-public void EventHook_PlayerSpawn(Event event, const char[] name, bool dontBroadcast)
+static void EventHook_PlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(event.GetInt("userid"));
 	
@@ -298,7 +298,7 @@ public void EventHook_PlayerSpawn(Event event, const char[] name, bool dontBroad
 	}
 }
 
-public void EventHook_PlayerChangeClass(Event event, const char[] name, bool dontBroadcast)
+static void EventHook_PlayerChangeClass(Event event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(event.GetInt("userid"));
 	
@@ -315,7 +315,7 @@ public void EventHook_PlayerChangeClass(Event event, const char[] name, bool don
 	}
 }
 
-public Action EventHook_PlayerBuyback(Event event, const char[] name, bool dontBroadcast)
+static Action EventHook_PlayerBuyback(Event event, const char[] name, bool dontBroadcast)
 {
 	if (mvm_broadcast_events.BoolValue)
 	{
@@ -338,7 +338,7 @@ public Action EventHook_PlayerBuyback(Event event, const char[] name, bool dontB
 	return Plugin_Changed;
 }
 
-public Action EventHook_PlayerUsedPowerupBottle(Event event, const char[] name, bool dontBroadcast)
+static Action EventHook_PlayerUsedPowerupBottle(Event event, const char[] name, bool dontBroadcast)
 {
 	if (mvm_broadcast_events.BoolValue)
 	{
@@ -361,7 +361,7 @@ public Action EventHook_PlayerUsedPowerupBottle(Event event, const char[] name, 
 	return Plugin_Changed;
 }
 
-public Action EventHook_PlayerPickupCurrency(Event event, const char[] name, bool dontBroadcast)
+static Action EventHook_PlayerPickupCurrency(Event event, const char[] name, bool dontBroadcast)
 {
 	int player = event.GetInt("player");
 	int currency = event.GetInt("currency");

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -158,7 +158,7 @@ static void EventHook_ArenaRoundStart(Event event, const char[] name, bool dontB
 {
 	for (int client = 1; client <= MaxClients; client++)
 	{
-		if (IsClientInGame(client))
+		if (IsClientInGame(client) && CanPlayerUpgrade(client))
 		{
 			// Forcibly close the upgrade menu when the round starts
 			SetEntProp(client, Prop_Send, "m_bInUpgradeZone", false);
@@ -288,7 +288,7 @@ static void EventHook_PlayerSpawn(Event event, const char[] name, bool dontBroad
 		TF2Attrib_SetByName(client, "mod see enemy health", 1.0);
 	}
 	
-	if (!IsInArenaMode())
+	if (!IsInArenaMode() && CanPlayerUpgrade(client))
 	{
 		// Tell players how to upgrade if they have not purchased anything yet
 		if (!MvMPlayer(client).HasPurchasedUpgrades)

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -376,21 +376,15 @@ static Action EventHook_PlayerPickupCurrency(Event event, const char[] name, boo
 	int currency = event.GetInt("currency");
 	
 	// This attribute is not implemented in TF2, let's do it ourselves
-	Address currency_bonus = TF2Attrib_GetByName(player, "currency bonus");
-	if (currency_bonus)
-	{
-		int newCurrency = RoundToCeil(currency * TF2Attrib_GetValue(currency_bonus));
-		int bonusCurrency = newCurrency - currency;
-		
-		// Give the player the bonus currency
-		MvMPlayer(player).Currency += bonusCurrency;
-		MvMPlayer(player).AcquiredCredits += bonusCurrency;
-		
-		event.SetInt("currency", newCurrency);
-		return Plugin_Changed;
-	}
+	int newCurrency = RoundToCeil(currency * TF2Attrib_HookValueFloat(1.0, "currency_bonus", player));
+	int bonusCurrency = newCurrency - currency;
 	
-	return Plugin_Continue;
+	// Give the player the bonus currency
+	MvMPlayer(player).Currency += bonusCurrency;
+	MvMPlayer(player).AcquiredCredits += bonusCurrency;
+	
+	event.SetInt("currency", newCurrency);
+	return Plugin_Changed;
 }
 
 static void RequestFrameCallback_SpeakDeathResponses(int userid)

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -158,7 +158,7 @@ static void EventHook_ArenaRoundStart(Event event, const char[] name, bool dontB
 {
 	for (int client = 1; client <= MaxClients; client++)
 	{
-		if (IsClientInGame(client) && CanPlayerUpgrade(client))
+		if (IsClientInGame(client) && IsPlayerAllowedToUpgrade(client))
 		{
 			// Forcibly close the upgrade menu when the round starts
 			SetEntProp(client, Prop_Send, "m_bInUpgradeZone", false);
@@ -294,7 +294,7 @@ static void EventHook_PlayerSpawn(Event event, const char[] name, bool dontBroad
 		TF2Attrib_SetByName(client, "mod see enemy health", 1.0);
 	}
 	
-	if (!IsInArenaMode() && CanPlayerUpgrade(client))
+	if (!IsInArenaMode() && IsPlayerAllowedToUpgrade(client))
 	{
 		// Tell players how to upgrade if they have not purchased anything yet
 		if (!MvMPlayer(client).HasPurchasedUpgrades)

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -301,7 +301,7 @@ TFTeam GetUpgradeTeam()
 	}
 }
 
-bool CanPlayerUpgrade(int client)
+bool IsPlayerAllowedToUpgrade(int client)
 {
 	return GetUpgradeTeam() == TFTeam_Any || TF2_GetClientTeam(client) == GetUpgradeTeam();
 }

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -277,3 +277,31 @@ int FormatCurrencyAmount(int amount, char[] buffer, int maxlength)
 		return Format(buffer, maxlength, "$%d", amount);
 	}
 }
+
+TFTeam GetUpgradeTeam()
+{
+	char teamName[16];
+	mvm_upgrades_team_restriction.GetString(teamName, sizeof(teamName));
+	
+	if (StrEqual("blue", teamName, false))
+	{
+		return TFTeam_Blue;
+	}
+	else if (StrEqual("red", teamName, false))
+	{
+		return TFTeam_Red;
+	}
+	else if (StrEqual(teamName, "spectator", false))
+	{
+		return TFTeam_Spectator;
+	}
+	else
+	{
+		return TFTeam_Any;
+	}
+}
+
+bool CanPlayerUpgrade(int client)
+{
+	return GetUpgradeTeam() == TFTeam_Any || TF2_GetClientTeam(client) == GetUpgradeTeam();
+}

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -278,10 +278,10 @@ int FormatCurrencyAmount(int amount, char[] buffer, int maxlength)
 	}
 }
 
-TFTeam GetUpgradeTeam()
+TFTeam GetDefenderTeam()
 {
 	char teamName[16];
-	mvm_upgrades_team_restriction.GetString(teamName, sizeof(teamName));
+	mvm_defender_team.GetString(teamName, sizeof(teamName));
 	
 	if (StrEqual("blue", teamName, false))
 	{
@@ -301,7 +301,7 @@ TFTeam GetUpgradeTeam()
 	}
 }
 
-bool IsPlayerAllowedToUpgrade(int client)
+bool IsPlayerDefender(int client)
 {
-	return GetUpgradeTeam() == TFTeam_Any || TF2_GetClientTeam(client) == GetUpgradeTeam();
+	return (GetDefenderTeam() == TFTeam_Any || TF2_GetClientTeam(client) == GetDefenderTeam());
 }

--- a/addons/sourcemod/scripting/mannvsmann/sdkcalls.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkcalls.sp
@@ -290,7 +290,7 @@ void SDKCall_DropCurrencyPack(int player, CurrencyRewards size = TF_CURRENCY_PAC
 	}
 }
 
-int SDKCall_GetEquippedWearableForLoadoutSlot(int player, int loadoutSlot)
+int SDKCall_GetEquippedWearableForLoadoutSlot(int player, LoadoutPosition loadoutSlot)
 {
 	if (g_SDKCallGetEquippedWearableForLoadoutSlot)
 	{

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -168,10 +168,12 @@ static Action CurrencyPack_SetTransmit(int currencypack, int client)
 	return Plugin_Continue;
 }
 
-static void SDKHookCB_Sapper_Spawn(int sapper)
+static Action SDKHookCB_Sapper_Spawn(int sapper)
 {
 	// Prevents repeat placement of sappers on players
 	SetMannVsMachineMode(true);
+	
+	return Plugin_Continue;
 }
 
 static void SDKHookCB_Sapper_SpawnPost(int sapper)

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -71,7 +71,7 @@ void SDKHooks_UnhookEntity(int entity, const char[] classname)
 	}
 }
 
-public Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+static Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
 	// OnTakeDamage may get called while CTFPlayerShared::ConditionGameRulesThink has MvM enabled.
 	// This causes unwanted things like defender death sounds and additional revive markers to appear, so we suppress it.
@@ -80,12 +80,12 @@ public Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &infl
 	return Plugin_Continue;
 }
 
-public void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
+static void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
 {
 	ResetMannVsMachineMode();
 }
 
-public Action SDKHookCB_Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+static Action SDKHookCB_Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
 	// Blast resistance also applies to self-inflicted damage in MvM
 	SetMannVsMachineMode(true);
@@ -118,12 +118,12 @@ public Action SDKHookCB_Client_OnTakeDamageAlive(int victim, int &attacker, int 
 	return Plugin_Continue;
 }
 
-public void SDKHookCB_Client_OnTakeDamageAlivePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
+static void SDKHookCB_Client_OnTakeDamageAlivePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
 {
 	ResetMannVsMachineMode();
 }
 
-public Action SDKHookCB_Regenerate_EndTouch(int regenerate, int other)
+static Action SDKHookCB_Regenerate_EndTouch(int regenerate, int other)
 {
 	if (IsValidClient(other))
 	{
@@ -133,7 +133,7 @@ public Action SDKHookCB_Regenerate_EndTouch(int regenerate, int other)
 	return Plugin_Continue;
 }
 
-public Action SDKHookCB_ReviveMarker_SetTransmit(int marker, int client)
+static Action SDKHookCB_ReviveMarker_SetTransmit(int marker, int client)
 {
 	// Only transmit revive markers to our own team and spectators
 	if (!IsEntVisibleToClient(marker, client))
@@ -144,7 +144,7 @@ public Action SDKHookCB_ReviveMarker_SetTransmit(int marker, int client)
 	return Plugin_Continue;
 }
 
-public void SDKHookCB_CurrencyPack_SpawnPost(int currencypack)
+static void SDKHookCB_CurrencyPack_SpawnPost(int currencypack)
 {
 	// Add the currency value to the world money
 	if (!GetEntProp(currencypack, Prop_Send, "m_bDistributed"))
@@ -157,7 +157,7 @@ public void SDKHookCB_CurrencyPack_SpawnPost(int currencypack)
 	SDKHook(currencypack, SDKHook_SetTransmit, CurrencyPack_SetTransmit);
 }
 
-public Action CurrencyPack_SetTransmit(int currencypack, int client)
+static Action CurrencyPack_SetTransmit(int currencypack, int client)
 {
 	// Only transmit currency packs to our own team and spectators
 	if (!IsEntVisibleToClient(currencypack, client))
@@ -168,18 +168,18 @@ public Action CurrencyPack_SetTransmit(int currencypack, int client)
 	return Plugin_Continue;
 }
 
-public void SDKHookCB_Sapper_Spawn(int sapper)
+static void SDKHookCB_Sapper_Spawn(int sapper)
 {
 	// Prevents repeat placement of sappers on players
 	SetMannVsMachineMode(true);
 }
 
-public void SDKHookCB_Sapper_SpawnPost(int sapper)
+static void SDKHookCB_Sapper_SpawnPost(int sapper)
 {
 	ResetMannVsMachineMode();
 }
 
-public Action SDKHookCB_RespawnRoom_Touch(int respawnroom, int other)
+static Action SDKHookCB_RespawnRoom_Touch(int respawnroom, int other)
 {
 	if (!IsInArenaMode() && mvm_spawn_protection.BoolValue && GameRules_GetRoundState() != RoundState_TeamWin)
 	{

--- a/addons/sourcemod/translations/mannvsmann.phrases.txt
+++ b/addons/sourcemod/translations/mannvsmann.phrases.txt
@@ -27,6 +27,10 @@
 		"en"		"You are not allowed to use the upgrade station at this time."
 		"ru"		"Вы не можете использовать станцию улучшений в данный момент."
 	}
+	"MvM_Hint_CannotUseCanteens"
+	{
+		"en"		"You are not allowed to use Power Up Canteens at this time."
+	}
 	"MvM_Buyback"
 	{
 		"#format"	"{1:d}"

--- a/addons/sourcemod/translations/mannvsmann.phrases.txt
+++ b/addons/sourcemod/translations/mannvsmann.phrases.txt
@@ -22,10 +22,16 @@
 		"en"		"Visit a resupply locker to purchase player and weapon upgrades!"
 		"ru"		"Подойдите к шкафчику c боеприпасами, чтобы приобрести улучшения для игрока и оружия!"
 	}
+	"MvM_Hint_CannotUpgrade"
+	{
+		"en"		"You are not allowed to use the upgrade station at this time."
+		"ru"		"Вы не можете использовать станцию улучшений в данный момент."
+	}
 	"MvM_Buyback"
 	{
 		"#format"	"{1:d}"
 		"en"		"Hit the 'Use Item in Action Slot' key to pay {1} credits and RESPAWN INSTANTLY!"
+		"ru"		"Нажмите 'Использовать предмет в ячейке действия', чтобы возродиться СЕЙЧАС за {1} кредитов!"
 	}
 	"MvM_Upgrade_DisposableSentry"
 	{


### PR DESCRIPTION
Adds 4 new plugin cvars:
* mvm_currency_hud_player
* mvm_currency_hud_spectator
* mvm_death_responses
* mvm_defender_team

Also makes use of attribute hooks instead of using simple value accessors on an entity.

Closes #17