### PR TITLE
Use ForceEnableUpgrades script method to enable upgrades

### DIFF
--- a/addons/sourcemod/gamedata/mannvsmann.txt
+++ b/addons/sourcemod/gamedata/mannvsmann.txt
@@ -39,11 +39,6 @@
 		}
 		"Signatures"
 		{
-			"CUpgrades::ApplyUpgradeToItem"
-			{
-				"linux"		"@_ZN9CUpgrades18ApplyUpgradeToItemEP9CTFPlayerP13CEconItemViewiibb"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x0C\x57\x8B\x7D\x08\x89\x4D\xF8"
-			}
 			"CPopulationManager::Update"
 			{
 				"linux"		"@_ZN18CPopulationManager6UpdateEv"
@@ -104,11 +99,6 @@
 				"linux"		"@_ZN15CTFPlayerShared19ApplyRocketPackStunEf"
 				"windows"	"\x55\x8B\xEC\xF3\x0F\x10\x05\x2A\x2A\x2A\x2A\x83\xEC\x7C"
 			}
-			"CTFPlayer::RemoveAllOwnedEntitiesFromWorld"
-			{
-				"linux"		"@_ZN9CTFPlayer31RemoveAllOwnedEntitiesFromWorldEb"
-				"windows"	"\x55\x8B\xEC\x56\x8B\xF1\xE8\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A"
-			}
 			"CTFPlayer::CanBuild"
 			{
 				"linux"		"@_ZN9CTFPlayer8CanBuildEii"
@@ -123,11 +113,6 @@
 			{
 				"linux"		"@_ZN9CTFPlayer33GetEquippedWearableForLoadoutSlotEi"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x2A\x8B\xC1\x53\x56\x33\xF6\x89\x45\xF8\x8B\x88\x2A\x2A\x2A\x2A\x57\x89\x4D\xFC"
-			}
-			"CTFPlayer::ManageRegularWeapons"
-			{
-				"linux"		"@_ZN9CTFPlayer20ManageRegularWeaponsEP19TFPlayerClassData_t"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x6C\x53\x56\x57\x8B\xF9\xE8\x2A\x2A\x2A\x2A"
 			}
 			"CTFPlayer::RegenThink"
 			{
@@ -240,40 +225,6 @@
 		}
 		"Functions"
 		{
-			"CUpgrades::ApplyUpgradeToItem"
-			{
-				"signature"	"CUpgrades::ApplyUpgradeToItem"
-				"callconv"	"thiscall"
-				"return"	"int"
-				"this"		"entity"
-				"arguments"
-				{
-					"pTFPlayer"
-					{
-						"type"	"cbaseentity"
-					}
-					"pView"
-					{
-						"type"	"int"
-					}
-					"iUpgrade"
-					{
-						"type"	"int"
-					}
-					"nCost"
-					{
-						"type"	"int"
-					}
-					"bDowngrade"
-					{
-						"type"	"bool"
-					}
-					"bIsFresh"
-					{
-						"type"	"bool"
-					}
-				}
-			}
 			"CPopulationManager::Update"
 			{
 				"signature"	"CPopulationManager::Update"
@@ -309,13 +260,6 @@
 			"CTFGameRules::IsQuickBuildTime"
 			{
 				"signature"	"CTFGameRules::IsQuickBuildTime"
-				"callconv"	"thiscall"
-				"return"	"bool"
-				"this"		"ignore"
-			}
-			"CTFGameRules::GameModeUsesUpgrades"
-			{
-				"address"	"CTFGameRules::GameModeUsesUpgrades"
 				"callconv"	"thiscall"
 				"return"	"bool"
 				"this"		"ignore"
@@ -392,20 +336,6 @@
 					}
 				}
 			}
-			"CTFPlayer::RemoveAllOwnedEntitiesFromWorld"
-			{
-				"signature"	"CTFPlayer::RemoveAllOwnedEntitiesFromWorld"
-				"callconv"	"thiscall"
-				"return"	"void"
-				"this"		"entity"
-				"arguments"
-				{
-					"bExplodeBuildings"
-					{
-						"type"	"bool"
-					}
-				}
-			}
 			"CTFPlayer::CanBuild"
 			{
 				"signature"	"CTFPlayer::CanBuild"
@@ -419,20 +349,6 @@
 						"type"	"int"
 					}
 					"iObjectMode"
-					{
-						"type"	"int"
-					}
-				}
-			}
-			"CTFPlayer::ManageRegularWeapons"
-			{
-				"signature"	"CTFPlayer::ManageRegularWeapons"
-				"callconv"	"thiscall"
-				"return"	"void"
-				"this"		"entity"
-				"arguments"
-				{
-					"pData"
 					{
 						"type"	"int"
 					}
@@ -610,20 +526,6 @@
 				{
 					"signature"	"CTFPlayerShared::RadiusCurrencyCollectionCheck"
 					"offset"	"26"	// +1A
-				}
-			}
-			// Reads the function address for CTFGameRules::GameModeUsesUpgrades
-			"CTFGameRules::GameModeUsesUpgrades"
-			{
-				"linux"
-				{
-					"signature" "CTFWeaponBase::PlayUpgradedShootSound"
-					"offset"	"38"	// +26
-				}
-				"windows"
-				{
-					"signature"	"CTFWeaponBase::PlayUpgradedShootSound"
-					"offset"	"19"	// +13
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -27,7 +27,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.10.2"
+#define PLUGIN_VERSION	"1.11.0"
 
 #define DEFAULT_UPGRADES_FILE	"scripts/items/mvm_upgrades.txt"
 

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -27,7 +27,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.11.0"
+#define PLUGIN_VERSION	"2.0.0"
 
 #define DEFAULT_UPGRADES_FILE	"scripts/items/mvm_upgrades.txt"
 
@@ -447,8 +447,10 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				{
 					SetVariantString("IsMvMDefender:1");
 					AcceptEntityInput(client, "AddContext");
+					
 					SetVariantString("TLK_MVM_UPGRADE_COMPLETE");
 					AcceptEntityInput(client, "SpeakResponseConcept");
+					
 					AcceptEntityInput(client, "ClearContext");
 				}
 				

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -183,10 +183,6 @@ ConVar mvm_currency_rewards_player_catchup_min;
 ConVar mvm_currency_rewards_player_catchup_max;
 ConVar mvm_currency_rewards_player_modifier_arena;
 ConVar mvm_currency_rewards_player_modifier_medieval;
-ConVar mvm_currency_hud_player;
-ConVar mvm_currency_hud_spectator;
-ConVar mvm_currency_hud_position_x;
-ConVar mvm_currency_hud_position_y;
 ConVar mvm_upgrades_reset_mode;
 ConVar mvm_showhealth;
 ConVar mvm_spawn_protection;
@@ -204,7 +200,6 @@ ConVar mvm_defender_team;
 TFTeam g_CurrencyPackTeam = TFTeam_Invalid;
 
 // Other globals
-Handle g_CurrencyHudSync;
 Handle g_BuybackHudSync;
 bool g_IsEnabled;
 bool g_IsMapRunning;
@@ -236,7 +231,6 @@ public void OnPluginStart()
 	LoadTranslations("common.phrases");
 	LoadTranslations("mannvsmann.phrases");
 	
-	g_CurrencyHudSync = CreateHudSynchronizer();
 	g_BuybackHudSync = CreateHudSynchronizer();
 	
 	Commands_Init();
@@ -590,6 +584,9 @@ void SetupOnMapStart()
 		SetCustomUpgradesFile(path);
 	}
 	
+	// Enable upgrades
+	ServerCommand("script ForceEnableUpgrades(2)");
+	
 	// Reset all teams
 	for (TFTeam team = TFTeam_Unassigned; team <= TFTeam_Blue; team++)
 	{
@@ -620,6 +617,9 @@ void TogglePlugin(bool enable)
 	}
 	else
 	{
+		// Disable upgrades
+		ServerCommand("script ForceEnableUpgrades(0)");
+		
 		RemoveNormalSoundHook(NormalSoundHook);
 		UnhookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);
 		
@@ -805,19 +805,6 @@ static Action Timer_UpdateHudText(Handle timer)
 						}
 					}
 				}
-				
-				// Show players how much currency they have outside of upgrade stations
-				if (!GetEntProp(client, Prop_Send, "m_bInUpgradeZone") && mvm_currency_hud_player.BoolValue && IsPlayerDefender(client))
-				{
-					SetHudTextParams(mvm_currency_hud_position_x.FloatValue, mvm_currency_hud_position_y.FloatValue, 0.1, 122, 196, 55, 255);
-					ShowSyncHudText(client, g_CurrencyHudSync, "$%d ($%d)", MvMPlayer(client).Currency, MvMTeam(team).WorldMoney);
-				}
-			}
-			else if (IsClientObserver(client) && mvm_currency_hud_spectator.BoolValue)
-			{
-				// Spectators can see currency stats for each team
-				SetHudTextParams(mvm_currency_hud_position_x.FloatValue, mvm_currency_hud_position_y.FloatValue, 0.1, 122, 196, 55, 255);
-				ShowSyncHudText(client, g_CurrencyHudSync, "BLU: $%d ($%d)\nRED: $%d ($%d)", MvMTeam(TFTeam_Blue).AcquiredCredits, MvMTeam(TFTeam_Blue).WorldMoney, MvMTeam(TFTeam_Red).AcquiredCredits, MvMTeam(TFTeam_Red).WorldMoney);
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -27,7 +27,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"2.0.0"
+#define PLUGIN_VERSION	"1.11.0"
 
 #define DEFAULT_UPGRADES_FILE	"scripts/items/mvm_upgrades.txt"
 

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -555,7 +555,8 @@ void SetupOnMapStart()
 	}
 	
 	// Enable upgrades
-	ServerCommand("script ForceEnableUpgrades(2)");
+	SetVariantString("ForceEnableUpgrades(2)");
+	AcceptEntityInput(0, "RunScriptCode");
 	
 	// Reset all teams
 	for (TFTeam team = TFTeam_Unassigned; team <= TFTeam_Blue; team++)
@@ -588,7 +589,8 @@ void TogglePlugin(bool enable)
 	else
 	{
 		// Disable upgrades
-		ServerCommand("script ForceEnableUpgrades(0)");
+		SetVariantString("ForceEnableUpgrades(0)");
+		AcceptEntityInput(0, "RunScriptCode");
 		
 		RemoveNormalSoundHook(NormalSoundHook);
 		UnhookEntityOutput("team_round_timer", "On10SecRemain", EntityOutput_OnTimer10SecRemain);

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -479,7 +479,7 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 		{
 			if (IsPlayerDefender(client))
 			{
-				// Required for td_buyback and CTFPowerupBottle::Use to work properly
+				// Required for td_buyback to work properly
 				SetMannVsMachineMode(true);
 				
 				if (IsClientObserver(client))

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -451,15 +451,6 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 				
 				CancelClientMenu(client);
 				
-				// Tell Engineers how to build disposable sentries
-				if (TF2_GetPlayerClass(client) == TFClass_Engineer)
-				{
-					if (TF2Attrib_HookValueInt(0, "engy_disposable_sentries", client))
-					{
-						PrintHintText(client, "%t", "MvM_Upgrade_DisposableSentry");
-					}
-				}
-				
 				if (IsInArenaMode())
 				{
 					// This code exists because the upgrade menu takes a while to fully close clientside.

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -29,10 +29,6 @@ void ConVars_Init()
 	mvm_currency_rewards_player_catchup_max = CreateConVar("mvm_currency_rewards_player_catchup_max", "1.5", "Maximum currency bonus multiplier for losing teams.", _, true, 1.0);
 	mvm_currency_rewards_player_modifier_arena = CreateConVar("mvm_currency_rewards_player_modifier_arena", "2.0", "Multiplier to dropped currency in arena mode.");
 	mvm_currency_rewards_player_modifier_medieval = CreateConVar("mvm_currency_rewards_player_modifier_medieval", "0.33", "Multiplier to dropped currency in medieval mode.");
-	mvm_currency_hud_player = CreateConVar("mvm_currency_hud_player", "1", "When set to 1, players will be shown their credits outside of upgrade stations.");
-	mvm_currency_hud_spectator = CreateConVar("mvm_currency_hud_spectator", "1", "When set to 1, spectators will be shown the credit values of each team.");
-	mvm_currency_hud_position_x = CreateConVar("mvm_currency_hud_position_x", "-1", "x coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
-	mvm_currency_hud_position_y = CreateConVar("mvm_currency_hud_position_y", "0.75", "y coordinate of the currency HUD message, from 0 to 1. -1.0 is the center.", _, true, -1.0, true, 1.0);
 	mvm_upgrades_reset_mode = CreateConVar("mvm_upgrades_reset_mode", "0", "How player upgrades and credits are reset after a full round has been played. 0 = Reset if teams are being switched or scrambled. 1 = Always reset. 2 = Never reset.");
 	mvm_showhealth = CreateConVar("mvm_showhealth", "0", "When set to 1, shows a floating health icon over enemy players.");
 	mvm_spawn_protection = CreateConVar("mvm_spawn_protection", "1", "When set to 1, players are granted ubercharge while they leave their spawn.");

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -47,20 +47,16 @@ void DHooks_Init(GameData gamedata)
 	g_DynamicHookIds = new ArrayList();
 	
 	// Create detours
-	DHooks_AddDynamicDetour(gamedata, "CUpgrades::ApplyUpgradeToItem", DHookCallback_ApplyUpgradeToItem_Pre, DHookCallback_ApplyUpgradeToItem_Post);
 	DHooks_AddDynamicDetour(gamedata, "CPopulationManager::Update", DHookCallback_PopulationManagerUpdate_Pre, _);
 	DHooks_AddDynamicDetour(gamedata, "CPopulationManager::ResetMap", DHookCallback_PopulationManagerResetMap_Pre, DHookCallback_PopulationManagerResetMap_Post);
 	DHooks_AddDynamicDetour(gamedata, "CCaptureFlag::Capture", DHookCallback_Capture_Pre, DHookCallback_Capture_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFGameRules::IsQuickBuildTime", DHookCallback_IsQuickBuildTime_Pre, DHookCallback_IsQuickBuildTime_Post);
-	DHooks_AddDynamicDetour(gamedata, "CTFGameRules::GameModeUsesUpgrades", _, DHookCallback_GameModeUsesUpgrades_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFGameRules::DistributeCurrencyAmount", DHookCallback_DistributeCurrencyAmount_Pre, DHookCallback_DistributeCurrencyAmount_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFPlayerShared::ConditionGameRulesThink", DHookCallback_ConditionGameRulesThink_Pre, DHookCallback_ConditionGameRulesThink_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFPlayerShared::CanRecieveMedigunChargeEffect", DHookCallback_CanRecieveMedigunChargeEffect_Pre, DHookCallback_CanRecieveMedigunChargeEffect_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFPlayerShared::RadiusSpyScan", DHookCallback_RadiusSpyScan_Pre, DHookCallback_RadiusSpyScan_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFPlayerShared::ApplyRocketPackStun", DHookCallback_ApplyRocketPackStun_Pre, DHookCallback_ApplyRocketPackStun_Post);
-	DHooks_AddDynamicDetour(gamedata, "CTFPlayer::RemoveAllOwnedEntitiesFromWorld", DHookCallback_RemoveAllOwnedEntitiesFromWorld_Pre, DHookCallback_RemoveAllOwnedEntitiesFromWorld_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFPlayer::CanBuild", DHookCallback_CanBuild_Pre, DHookCallback_CanBuild_Post);
-	DHooks_AddDynamicDetour(gamedata, "CTFPlayer::ManageRegularWeapons", DHookCallback_ManageRegularWeapons_Pre, DHookCallback_ManageRegularWeapons_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFPlayer::RegenThink", DHookCallback_RegenThink_Pre, DHookCallback_RegenThink_Post);
 	DHooks_AddDynamicDetour(gamedata, "CBaseObject::FindSnapToBuildPos", DHookCallback_FindSnapToBuildPos_Pre, DHookCallback_FindSnapToBuildPos_Post);
 	DHooks_AddDynamicDetour(gamedata, "CBaseObject::ShouldQuickBuild", DHookCallback_ShouldQuickBuild_Pre, DHookCallback_ShouldQuickBuild_Post);
@@ -233,21 +229,6 @@ public void DHookRemovalCB_OnHookRemoved(int hookid)
 	}
 }
 
-static MRESReturn DHookCallback_ApplyUpgradeToItem_Pre(int upgradestation, DHookReturn ret, DHookParam params)
-{
-	// This function has some special logic for MvM that we want
-	SetMannVsMachineMode(true);
-	
-	return MRES_Ignored;
-}
-
-static MRESReturn DHookCallback_ApplyUpgradeToItem_Post(int upgradestation, DHookReturn ret, DHookParam params)
-{
-	ResetMannVsMachineMode();
-	
-	return MRES_Ignored;
-}
-
 static MRESReturn DHookCallback_PopulationManagerUpdate_Pre(int populator)
 {
 	// Prevents the populator from messing with the GC and allocating bots
@@ -309,14 +290,6 @@ static MRESReturn DHookCallback_IsQuickBuildTime_Post(DHookReturn ret)
 	ResetMannVsMachineMode();
 	
 	return MRES_Ignored;
-}
-
-static MRESReturn DHookCallback_GameModeUsesUpgrades_Post(DHookReturn ret)
-{
-	// Fixes various upgrades and enables a few MvM-related features
-	ret.Value = true;
-	
-	return MRES_Supercede;
 }
 
 static MRESReturn DHookCallback_DistributeCurrencyAmount_Pre(DHookReturn ret, DHookParam params)
@@ -501,27 +474,6 @@ static MRESReturn DHookCallback_ApplyRocketPackStun_Post(Address pShared, DHookP
 	return MRES_Ignored;
 }
 
-static MRESReturn DHookCallback_RemoveAllOwnedEntitiesFromWorld_Pre(int player, DHookParam params)
-{
-	// MvM invaders are allowed to keep their buildings and we don't want that, move the player to the defender team
-	if (IsMannVsMachineMode())
-	{
-		MvMPlayer(player).SetTeam(TFTeam_Red);
-	}
-	
-	return MRES_Ignored;
-}
-
-static MRESReturn DHookCallback_RemoveAllOwnedEntitiesFromWorld_Post(int player, DHookParam params)
-{
-	if (IsMannVsMachineMode())
-	{
-		MvMPlayer(player).ResetTeam();
-	}
-	
-	return MRES_Ignored;
-}
-
 static MRESReturn DHookCallback_CanBuild_Pre(int player, DHookReturn ret, DHookParam params)
 {
 	// Limits the amount of sappers that can be placed on players
@@ -531,21 +483,6 @@ static MRESReturn DHookCallback_CanBuild_Pre(int player, DHookReturn ret, DHookP
 }
 
 static MRESReturn DHookCallback_CanBuild_Post(int player, DHookReturn ret, DHookParam params)
-{
-	ResetMannVsMachineMode();
-	
-	return MRES_Ignored;
-}
-
-static MRESReturn DHookCallback_ManageRegularWeapons_Pre(int player, DHookParam params)
-{
-	// Allows the call to CTFPlayer::ReapplyPlayerUpgrades to happen
-	SetMannVsMachineMode(true);
-	
-	return MRES_Ignored;
-}
-
-static MRESReturn DHookCallback_ManageRegularWeapons_Post(int player, DHookParam params)
 {
 	ResetMannVsMachineMode();
 	

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -185,12 +185,6 @@ static void EventHook_PostInventoryApplication(Event event, const char[] name, b
 
 static void EventHook_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
 {
-	// Never do this for mass-switches as it may lead to buffer overflows
-	if (SDKCall_ShouldSwitchTeams() || SDKCall_ShouldScrambleTeams())
-	{
-		return;
-	}
-	
 	int client = GetClientOfUserId(event.GetInt("userid"));
 	TFTeam team = view_as<TFTeam>(event.GetInt("team"));
 	

--- a/addons/sourcemod/translations/mannvsmann.phrases.txt
+++ b/addons/sourcemod/translations/mannvsmann.phrases.txt
@@ -37,11 +37,6 @@
 		"en"		"Hit the 'Use Item in Action Slot' key to pay {1} credits and RESPAWN INSTANTLY!"
 		"ru"		"Нажмите 'Использовать предмет в ячейке действия', чтобы возродиться СЕЙЧАС за {1} кредитов!"
 	}
-	"MvM_Upgrade_DisposableSentry"
-	{
-		"en"		"Use the 'build 2' console command ('%%build 2%%') to build a Disposable Sentry Gun."
-		"ru"		"Используйте консольную команду 'build 2' ('%%build 2%%'), чтобы построить одноразовую турель."
-	}
 	"MvM_CurrencyAdded"
 	{
 		"#format"	"{1:s},{2:t}"


### PR DESCRIPTION
Instead of detouring `GamemodeUsesUpgrades` we can now call VScript function `ForceEnableUpgrades(2)` which allows client stuff to work too.

* Remove currency display text and all convars related to it
* Remove hints on how to build disposable sentry guns
* Remove several unnecessary detours related to upgrades