### PR TITLE
Rename plugin ConVars

### DIFF
--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -27,7 +27,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.11.2"
+#define PLUGIN_VERSION	"1.12"
 
 #define DEFAULT_UPGRADES_FILE	"scripts/items/mvm_upgrades.txt"
 

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -177,26 +177,26 @@ char g_PlayerClassNames[][] =
 // ConVars
 ConVar tf_avoidteammates_pushaway;
 
-ConVar mvm_enable;
-ConVar mvm_currency_starting;
-ConVar mvm_currency_rewards_player_killed;
-ConVar mvm_currency_rewards_player_count_bonus;
-ConVar mvm_currency_rewards_player_catchup_min;
-ConVar mvm_currency_rewards_player_catchup_max;
-ConVar mvm_currency_rewards_player_modifier_arena;
-ConVar mvm_currency_rewards_player_modifier_medieval;
-ConVar mvm_upgrades_reset_mode;
-ConVar mvm_showhealth;
-ConVar mvm_spawn_protection;
-ConVar mvm_enable_music;
-ConVar mvm_gas_explode_damage_modifier;
-ConVar mvm_medigun_shield_damage_modifier;
-ConVar mvm_radius_spy_scan;
-ConVar mvm_revive_markers;
-ConVar mvm_broadcast_events;
-ConVar mvm_custom_upgrades_file;
-ConVar mvm_death_responses;
-ConVar mvm_defender_team;
+ConVar sm_mvm_enable;
+ConVar sm_mvm_currency_starting;
+ConVar sm_mvm_currency_rewards_player_killed;
+ConVar sm_mvm_currency_rewards_player_count_bonus;
+ConVar sm_mvm_currency_rewards_player_catchup_min;
+ConVar sm_mvm_currency_rewards_player_catchup_max;
+ConVar sm_mvm_currency_rewards_player_modifier_arena;
+ConVar sm_mvm_currency_rewards_player_modifier_medieval;
+ConVar sm_mvm_upgrades_reset_mode;
+ConVar sm_mvm_showhealth;
+ConVar sm_mvm_spawn_protection;
+ConVar sm_mvm_enable_music;
+ConVar sm_mvm_gas_explode_damage_modifier;
+ConVar sm_mvm_medigun_shield_damage_modifier;
+ConVar sm_mvm_radius_spy_scan;
+ConVar sm_mvm_revive_markers;
+ConVar sm_mvm_broadcast_events;
+ConVar sm_mvm_custom_upgrades_file;
+ConVar sm_mvm_death_responses;
+ConVar sm_mvm_defender_team;
 
 // DHooks
 TFTeam g_CurrencyPackTeam = TFTeam_Invalid;
@@ -277,9 +277,9 @@ public void OnMapEnd()
 
 public void OnConfigsExecuted()
 {
-	if (g_IsEnabled != mvm_enable.BoolValue)
+	if (g_IsEnabled != sm_mvm_enable.BoolValue)
 	{
-		TogglePlugin(mvm_enable.BoolValue);
+		TogglePlugin(sm_mvm_enable.BoolValue);
 	}
 	else if (g_IsEnabled)
 	{
@@ -567,7 +567,7 @@ void SetupOnMapStart()
 	
 	// Set custom upgrades file and add it to downloads
 	char path[PLATFORM_MAX_PATH];
-	mvm_custom_upgrades_file.GetString(path, sizeof(path));
+	sm_mvm_custom_upgrades_file.GetString(path, sizeof(path));
 	if (path[0])
 	{
 		SetCustomUpgradesFile(path);
@@ -695,7 +695,7 @@ void TogglePlugin(bool enable)
 
 static Action EntityOutput_OnTimer10SecRemain(const char[] output, int caller, int activator, float delay)
 {
-	if (mvm_enable_music.BoolValue)
+	if (sm_mvm_enable_music.BoolValue)
 	{
 		if (GameRules_GetProp("m_bInSetup"))
 		{
@@ -820,7 +820,7 @@ static int MenuHandler_UpgradeRespec(Menu menu, MenuAction action, int param1, i
 					if (populator != -1)
 					{
 						// This should put us at the right currency, given that we've removed item and player upgrade tracking by this point
-						int totalAcquiredCurrency = MvMTeam(TF2_GetClientTeam(param1)).AcquiredCredits + MvMPlayer(param1).AcquiredCredits + mvm_currency_starting.IntValue;
+						int totalAcquiredCurrency = MvMTeam(TF2_GetClientTeam(param1)).AcquiredCredits + MvMPlayer(param1).AcquiredCredits + sm_mvm_currency_starting.IntValue;
 						int spentCurrency = SDKCall_GetPlayerCurrencySpent(populator, param1);
 						MvMPlayer(param1).Currency = totalAcquiredCurrency - spentCurrency;
 					}

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -22,45 +22,45 @@ void ConVars_Init()
 {
 	tf_avoidteammates_pushaway = FindConVar("tf_avoidteammates_pushaway");
 	
-	CreateConVar("mvm_version", PLUGIN_VERSION, "Mann vs. Mann plugin version", FCVAR_SPONLY | FCVAR_REPLICATED | FCVAR_NOTIFY | FCVAR_DONTRECORD);
-	mvm_enable = CreateConVar("mvm_enable", "1", "When set, the plugin will be enabled.");
-	mvm_currency_starting = CreateConVar("mvm_currency_starting", "1000", "Number of credits that players get at the start of a match.", _, true, 0.0);
-	mvm_currency_rewards_player_killed = CreateConVar("mvm_currency_rewards_player_killed", "15", "The fixed number of credits dropped by players on death.");
-	mvm_currency_rewards_player_count_bonus = CreateConVar("mvm_currency_rewards_player_count_bonus", "2.0", "Multiplier to dropped currency that gradually increases up to this value until all player slots have been filled.", _, true, 1.0);
-	mvm_currency_rewards_player_catchup_min = CreateConVar("mvm_currency_rewards_player_catchup_min", "0.66", "Maximum currency penalty multiplier for winning teams", _, true, 0.0, true, 1.0);
-	mvm_currency_rewards_player_catchup_max = CreateConVar("mvm_currency_rewards_player_catchup_max", "1.5", "Maximum currency bonus multiplier for losing teams.", _, true, 1.0);
-	mvm_currency_rewards_player_modifier_arena = CreateConVar("mvm_currency_rewards_player_modifier_arena", "2.0", "Multiplier to dropped currency in arena mode.");
-	mvm_currency_rewards_player_modifier_medieval = CreateConVar("mvm_currency_rewards_player_modifier_medieval", "0.33", "Multiplier to dropped currency in medieval mode.");
-	mvm_upgrades_reset_mode = CreateConVar("mvm_upgrades_reset_mode", "0", "How player upgrades and credits are reset after a full round has been played. 0 = Reset if teams are being switched or scrambled. 1 = Always reset. 2 = Never reset.");
-	mvm_showhealth = CreateConVar("mvm_showhealth", "0", "When set to 1, shows a floating health icon over enemy players.");
-	mvm_spawn_protection = CreateConVar("mvm_spawn_protection", "1", "When set to 1, players are granted ubercharge while they leave their spawn.");
-	mvm_enable_music = CreateConVar("mvm_enable_music", "1", "When set to 1, Mann vs. Machine music will play at the start and end of a round.");
-	mvm_gas_explode_damage_modifier = CreateConVar("mvm_gas_explode_damage_modifier", "0.5", "Multiplier to damage of the explosion created by the Gas Passer's 'Explode On Ignite' upgrade.");
-	mvm_medigun_shield_damage_modifier = CreateConVar("mvm_medigun_shield_damage_modifier", "0", "Multiplier to damage of the shield created by the Medi Gun's 'Projectile Shield' upgrade.");
-	mvm_radius_spy_scan = CreateConVar("mvm_radius_spy_scan", "1", "When set to 1, Spies will reveal cloaked enemy Spies in a radius.");
-	mvm_revive_markers = CreateConVar("mvm_revive_markers", "1", "When set to 1, players will create revive markers on death.");
-	mvm_broadcast_events = CreateConVar("mvm_broadcast_events", "0", "When set to 1, the 'player_buyback' and 'player_used_powerup_bottle' events will be broadcast to all players.");
-	mvm_custom_upgrades_file = CreateConVar("mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
-	mvm_death_responses = CreateConVar("mvm_death_responses", "0", "When set to 1, players will announce their teammate's deaths.");
-	mvm_defender_team = CreateConVar("mvm_defender_team", "any", "Determines which team is allowed to use Mann vs. Machine Defender mechanics. {any, blue, red, spectator}");
+	CreateConVar("sm_mvm_version", PLUGIN_VERSION, "Mann vs. Mann plugin version", FCVAR_SPONLY | FCVAR_REPLICATED | FCVAR_NOTIFY | FCVAR_DONTRECORD);
+	sm_mvm_enable = CreateConVar("sm_mvm_enable", "1", "When set, the plugin will be enabled.");
+	sm_mvm_currency_starting = CreateConVar("sm_mvm_currency_starting", "1000", "Number of credits that players get at the start of a match.", _, true, 0.0);
+	sm_mvm_currency_rewards_player_killed = CreateConVar("sm_mvm_currency_rewards_player_killed", "15", "The fixed number of credits dropped by players on death.");
+	sm_mvm_currency_rewards_player_count_bonus = CreateConVar("sm_mvm_currency_rewards_player_count_bonus", "2.0", "Multiplier to dropped currency that gradually increases up to this value until all player slots have been filled.", _, true, 1.0);
+	sm_mvm_currency_rewards_player_catchup_min = CreateConVar("sm_mvm_currency_rewards_player_catchup_min", "0.66", "Maximum currency penalty multiplier for winning teams", _, true, 0.0, true, 1.0);
+	sm_mvm_currency_rewards_player_catchup_max = CreateConVar("sm_mvm_currency_rewards_player_catchup_max", "1.5", "Maximum currency bonus multiplier for losing teams.", _, true, 1.0);
+	sm_mvm_currency_rewards_player_modifier_arena = CreateConVar("sm_mvm_currency_rewards_player_modifier_arena", "2.0", "Multiplier to dropped currency in arena mode.");
+	sm_mvm_currency_rewards_player_modifier_medieval = CreateConVar("sm_mvm_currency_rewards_player_modifier_medieval", "0.33", "Multiplier to dropped currency in medieval mode.");
+	sm_mvm_upgrades_reset_mode = CreateConVar("sm_mvm_upgrades_reset_mode", "0", "How player upgrades and credits are reset after a full round has been played. 0 = Reset if teams are being switched or scrambled. 1 = Always reset. 2 = Never reset.");
+	sm_mvm_showhealth = CreateConVar("sm_mvm_showhealth", "0", "When set to 1, shows a floating health icon over enemy players.");
+	sm_mvm_spawn_protection = CreateConVar("sm_mvm_spawn_protection", "1", "When set to 1, players are granted ubercharge while they leave their spawn.");
+	sm_mvm_enable_music = CreateConVar("sm_mvm_enable_music", "1", "When set to 1, Mann vs. Machine music will play at the start and end of a round.");
+	sm_mvm_gas_explode_damage_modifier = CreateConVar("sm_mvm_gas_explode_damage_modifier", "0.5", "Multiplier to damage of the explosion created by the Gas Passer's 'Explode On Ignite' upgrade.");
+	sm_mvm_medigun_shield_damage_modifier = CreateConVar("sm_mvm_medigun_shield_damage_modifier", "0", "Multiplier to damage of the shield created by the Medi Gun's 'Projectile Shield' upgrade.");
+	sm_mvm_radius_spy_scan = CreateConVar("sm_mvm_radius_spy_scan", "1", "When set to 1, Spies will reveal cloaked enemy Spies in a radius.");
+	sm_mvm_revive_markers = CreateConVar("sm_mvm_revive_markers", "1", "When set to 1, players will create revive markers on death.");
+	sm_mvm_broadcast_events = CreateConVar("sm_mvm_broadcast_events", "0", "When set to 1, the 'player_buyback' and 'player_used_powerup_bottle' events will be broadcast to all players.");
+	sm_mvm_custom_upgrades_file = CreateConVar("sm_mvm_custom_upgrades_file", "", "Custom upgrade menu file to use, set to an empty string to use the default.");
+	sm_mvm_death_responses = CreateConVar("sm_mvm_death_responses", "0", "When set to 1, players will announce their teammate's deaths.");
+	sm_mvm_defender_team = CreateConVar("sm_mvm_defender_team", "any", "Determines which team is allowed to use Mann vs. Machine Defender mechanics. {any, blue, red, spectator}");
 	
 	// Always keep this hook active
-	mvm_enable.AddChangeHook(ConVarChanged_Enable);
+	sm_mvm_enable.AddChangeHook(ConVarChanged_Enable);
 }
 
 void ConVars_Toggle(bool enable)
 {
 	if (enable)
 	{
-		mvm_showhealth.AddChangeHook(ConVarChanged_ShowHealth);
-		mvm_custom_upgrades_file.AddChangeHook(ConVarChanged_CustomUpgradesFile);
-		mvm_currency_starting.AddChangeHook(ConVarChanged_StartingCurrency);
+		sm_mvm_showhealth.AddChangeHook(ConVarChanged_ShowHealth);
+		sm_mvm_custom_upgrades_file.AddChangeHook(ConVarChanged_CustomUpgradesFile);
+		sm_mvm_currency_starting.AddChangeHook(ConVarChanged_StartingCurrency);
 	}
 	else
 	{
-		mvm_showhealth.RemoveChangeHook(ConVarChanged_ShowHealth);
-		mvm_custom_upgrades_file.RemoveChangeHook(ConVarChanged_CustomUpgradesFile);
-		mvm_currency_starting.RemoveChangeHook(ConVarChanged_StartingCurrency);
+		sm_mvm_showhealth.RemoveChangeHook(ConVarChanged_ShowHealth);
+		sm_mvm_custom_upgrades_file.RemoveChangeHook(ConVarChanged_CustomUpgradesFile);
+		sm_mvm_currency_starting.RemoveChangeHook(ConVarChanged_StartingCurrency);
 	}
 }
 

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -394,7 +394,7 @@ static MRESReturn DHookCallback_RadiusSpyScan_Pre(Address pShared)
 	TFTeam team = TF2_GetClientTeam(player);
 	
 	// This MvM feature may confuse players, so we allow servers to toggle it
-	if (!mvm_radius_spy_scan.BoolValue)
+	if (!sm_mvm_radius_spy_scan.BoolValue)
 	{
 		MvMPlayer(player).SetTeam(TFTeam_Spectator);
 		return MRES_Ignored;
@@ -430,7 +430,7 @@ static MRESReturn DHookCallback_RadiusSpyScan_Post(Address pShared)
 {
 	int player = TF2Util_GetPlayerFromSharedAddress(pShared);
 	
-	if (!mvm_radius_spy_scan.BoolValue)
+	if (!sm_mvm_radius_spy_scan.BoolValue)
 	{
 		MvMPlayer(player).ResetTeam();
 		return MRES_Ignored;
@@ -669,7 +669,7 @@ static MRESReturn DHookCallback_SetWinningTeam_Post(DHookParam params)
 	bool switchTeams = params.Get(4);
 	
 	// Determine whether our CTFGameRules::RoundRespawn hook will reset the map
-	int mode = mvm_upgrades_reset_mode.IntValue;
+	int mode = sm_mvm_upgrades_reset_mode.IntValue;
 	g_ForceMapReset = forceMapReset && (mode == RESET_MODE_ALWAYS || (mode == RESET_MODE_TEAM_SWITCH && (switchTeams || SDKCall_ShouldScrambleTeams())));
 	
 	return MRES_Ignored;
@@ -734,7 +734,7 @@ static MRESReturn DHookCallback_RoundRespawn_Pre()
 				{
 					int spentCurrency = SDKCall_GetPlayerCurrencySpent(populator, client);
 					SDKCall_AddPlayerCurrencySpent(populator, client, -spentCurrency);
-					MvMPlayer(client).Currency = mvm_currency_starting.IntValue;
+					MvMPlayer(client).Currency = sm_mvm_currency_starting.IntValue;
 					MvMPlayer(client).AcquiredCredits = 0;
 				}
 			}

--- a/addons/sourcemod/scripting/mannvsmann/events.sp
+++ b/addons/sourcemod/scripting/mannvsmann/events.sp
@@ -103,7 +103,7 @@ static Action EventHook_TeamplayBroadcastAudio(Event event, const char[] name, b
 		}
 	}
 	
-	if (mvm_enable_music.BoolValue)
+	if (sm_mvm_enable_music.BoolValue)
 	{
 		if (!strcmp(sound, "Game.YourTeamWon"))
 		{
@@ -197,7 +197,7 @@ static void EventHook_PlayerTeam(Event event, const char[] name, bool dontBroadc
 		if (populator != -1)
 		{
 			// This should put us at the right currency, given that we've removed item and player upgrade tracking by this point
-			int totalAcquiredCurrency = MvMTeam(team).AcquiredCredits + MvMPlayer(client).AcquiredCredits + mvm_currency_starting.IntValue;
+			int totalAcquiredCurrency = MvMTeam(team).AcquiredCredits + MvMPlayer(client).AcquiredCredits + sm_mvm_currency_starting.IntValue;
 			int spentCurrency = SDKCall_GetPlayerCurrencySpent(populator, client);
 			MvMPlayer(client).Currency = totalAcquiredCurrency - spentCurrency;
 		}
@@ -269,7 +269,7 @@ static void EventHook_PlayerDeath(Event event, const char[] name, bool dontBroad
 			EmitGameSoundToClient(victim, "MVM.PlayerDied");
 		}
 		
-		if (!IsInArenaMode() && mvm_revive_markers.BoolValue)
+		if (!IsInArenaMode() && sm_mvm_revive_markers.BoolValue)
 		{
 			if (!(death_flags & TF_DEATHFLAG_DEADRINGER) && !silent_kill)
 			{
@@ -281,7 +281,7 @@ static void EventHook_PlayerDeath(Event event, const char[] name, bool dontBroad
 			}
 		}
 		
-		if (mvm_death_responses.BoolValue)
+		if (sm_mvm_death_responses.BoolValue)
 		{
 			// The victim is still considered alive here, so we do voice line stuff one frame later
 			RequestFrame(RequestFrameCallback_SpeakDeathResponses, GetClientUserId(victim));
@@ -293,7 +293,7 @@ static void EventHook_PlayerSpawn(Event event, const char[] name, bool dontBroad
 {
 	int client = GetClientOfUserId(event.GetInt("userid"));
 	
-	if (mvm_showhealth.BoolValue)
+	if (sm_mvm_showhealth.BoolValue)
 	{
 		// Allow players to see enemy health
 		TF2Attrib_SetByName(client, "mod see enemy health", 1.0);
@@ -328,7 +328,7 @@ static void EventHook_PlayerChangeClass(Event event, const char[] name, bool don
 
 static Action EventHook_PlayerBuyback(Event event, const char[] name, bool dontBroadcast)
 {
-	if (mvm_broadcast_events.BoolValue)
+	if (sm_mvm_broadcast_events.BoolValue)
 	{
 		return Plugin_Continue;
 	}
@@ -351,7 +351,7 @@ static Action EventHook_PlayerBuyback(Event event, const char[] name, bool dontB
 
 static Action EventHook_PlayerUsedPowerupBottle(Event event, const char[] name, bool dontBroadcast)
 {
-	if (mvm_broadcast_events.BoolValue)
+	if (sm_mvm_broadcast_events.BoolValue)
 	{
 		return Plugin_Continue;
 	}

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -196,7 +196,7 @@ int GetPlayingClientCount()
 int CalculateCurrencyAmount(int attacker)
 {
 	// Base currency amount
-	float amount = mvm_currency_rewards_player_killed.FloatValue;
+	float amount = sm_mvm_currency_rewards_player_killed.FloatValue;
 	
 	if (!amount)
 	{
@@ -210,8 +210,8 @@ int CalculateCurrencyAmount(int attacker)
 		float redMult = MvMTeam(TFTeam_Red).AcquiredCredits ? float(MvMTeam(TFTeam_Blue).AcquiredCredits) / float(MvMTeam(TFTeam_Red).AcquiredCredits) : 1.0;
 		float blueMult = MvMTeam(TFTeam_Blue).AcquiredCredits ? float(MvMTeam(TFTeam_Red).AcquiredCredits) / float(MvMTeam(TFTeam_Blue).AcquiredCredits) : 1.0;
 		
-		float penaltyMult = mvm_currency_rewards_player_catchup_min.FloatValue;
-		float bonusMult = mvm_currency_rewards_player_catchup_max.FloatValue;
+		float penaltyMult = sm_mvm_currency_rewards_player_catchup_min.FloatValue;
+		float bonusMult = sm_mvm_currency_rewards_player_catchup_max.FloatValue;
 		
 		// Clamp it so it doesn't reach into insanity
 		redMult = Clamp(redMult, penaltyMult, bonusMult);
@@ -230,17 +230,17 @@ int CalculateCurrencyAmount(int attacker)
 	// Modify currency amount in arena mode
 	if (IsInArenaMode())
 	{
-		amount *= mvm_currency_rewards_player_modifier_arena.FloatValue;
+		amount *= sm_mvm_currency_rewards_player_modifier_arena.FloatValue;
 	}
 	
 	// Modify currency amount in medieval mode
 	if (GameRules_GetProp("m_bPlayingMedieval"))
 	{
-		amount *= mvm_currency_rewards_player_modifier_medieval.FloatValue;
+		amount *= sm_mvm_currency_rewards_player_modifier_medieval.FloatValue;
 	}
 	
 	// Add low player count bonus
-	float playerMult = (mvm_currency_rewards_player_count_bonus.FloatValue - 1.0) / MaxClients * (MaxClients - GetPlayingClientCount());
+	float playerMult = (sm_mvm_currency_rewards_player_count_bonus.FloatValue - 1.0) / MaxClients * (MaxClients - GetPlayingClientCount());
 	amount += amount * playerMult;
 	
 	return RoundToCeil(amount);
@@ -261,7 +261,7 @@ int FormatCurrencyAmount(int amount, char[] buffer, int maxlength)
 TFTeam GetDefenderTeam()
 {
 	char teamName[16];
-	mvm_defender_team.GetString(teamName, sizeof(teamName));
+	sm_mvm_defender_team.GetString(teamName, sizeof(teamName));
 	
 	if (StrEqual("blue", teamName, false))
 	{

--- a/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
+++ b/addons/sourcemod/scripting/mannvsmann/methodmaps.sp
@@ -140,7 +140,7 @@ methodmap MvMPlayer
 		this.HasPurchasedUpgrades = false;
 		this.IsClosingUpgradeMenu = false;
 		this.AcquiredCredits = 0;
-		this.Currency = mvm_currency_starting.IntValue;
+		this.Currency = sm_mvm_currency_starting.IntValue;
 	}
 }
 

--- a/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/sdkhooks.sp
@@ -99,7 +99,7 @@ static Action SDKHookCB_Client_OnTakeDamageAlive(int victim, int &attacker, int 
 		{
 			if (damagetype & DMG_SLASH)
 			{
-				damage *= mvm_gas_explode_damage_modifier.FloatValue;
+				damage *= sm_mvm_gas_explode_damage_modifier.FloatValue;
 				return Plugin_Changed;
 			}
 		}
@@ -111,7 +111,7 @@ static Action SDKHookCB_Client_OnTakeDamageAlive(int victim, int &attacker, int 
 		char classname[32];
 		if (GetEntityClassname(inflictor, classname, sizeof(classname)) && !strcmp(classname, "entity_medigun_shield"))
 		{
-			damage *= mvm_medigun_shield_damage_modifier.FloatValue;
+			damage *= sm_mvm_medigun_shield_damage_modifier.FloatValue;
 			return Plugin_Changed;
 		}
 	}
@@ -214,7 +214,7 @@ static void SDKHookCB_Sapper_SpawnPost(int sapper)
 
 static Action SDKHookCB_RespawnRoom_Touch(int respawnroom, int other)
 {
-	if (!IsInArenaMode() && mvm_spawn_protection.BoolValue && GameRules_GetRoundState() != RoundState_TeamWin)
+	if (!IsInArenaMode() && sm_mvm_spawn_protection.BoolValue && GameRules_GetRoundState() != RoundState_TeamWin)
 	{
 		// Players get uber while they leave their spawn so they don't drop their cash where enemies can't pick it up
 		if (!GetEntProp(respawnroom, Prop_Data, "m_bDisabled") && IsValidClient(other) && TF2_GetTeam(respawnroom) == TF2_GetClientTeam(other))


### PR DESCRIPTION
Renames all plugin convars to follow the standard naming convention for plugins.

Should have been done before plugin release, but better now than never.