### PR TITLE
Implement armor_piercing attribute

### DIFF
--- a/addons/sourcemod/gamedata/mannvsmann.txt
+++ b/addons/sourcemod/gamedata/mannvsmann.txt
@@ -167,6 +167,11 @@
 				"linux"		"234"
 				"windows"	"231"
 			}
+			"CTFWeaponBaseMelee::GetMeleeDamage"
+			{
+				"linux"		"481"
+				"windows"	"474"
+			}
 			"CTFGameRules::SetWinningTeam"
 			{
 				"linux"		"165"
@@ -448,6 +453,28 @@
 					"pPlayer"
 					{
 						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CTFWeaponBaseMelee::GetMeleeDamage"
+			{
+				"offset"	"CTFWeaponBaseMelee::GetMeleeDamage"
+				"hooktype"	"entity"
+				"return"	"float"
+				"this"		"entity"
+				"arguments"
+				{
+					"pTarget"
+					{
+						"type"	"cbaseentity"
+					}
+					"piDamageType"
+					{
+						"type"	"int"
+					}
+					"piCustomDamage"
+					{
+						"type"	"int"
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -27,7 +27,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.12.0"
+#define PLUGIN_VERSION	"1.13.0"
 
 #define DEFAULT_UPGRADES_FILE	"scripts/items/mvm_upgrades.txt"
 
@@ -198,6 +198,7 @@ ConVar sm_mvm_custom_upgrades_file;
 ConVar sm_mvm_death_responses;
 ConVar sm_mvm_defender_team;
 ConVar sm_mvm_arena_canteens;
+ConVar sm_mvm_backstab_armor_piercing;
 
 // DHooks
 TFTeam g_CurrencyPackTeam = TFTeam_Invalid;

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -44,6 +44,7 @@ void ConVars_Init()
 	sm_mvm_death_responses = CreateConVar("sm_mvm_death_responses", "0", "When set to 1, players will announce their teammate's deaths.");
 	sm_mvm_defender_team = CreateConVar("sm_mvm_defender_team", "any", "Determines which team is allowed to use Mann vs. Machine Defender mechanics. {any, blue, red, spectator}");
 	sm_mvm_arena_canteens = CreateConVar("sm_mvm_arena_canteens", "1", "When set to 1, Power Up Canteens may be used in arena mode.");
+	sm_mvm_backstab_armor_piercing = CreateConVar("sm_mvm_backstab_armor_piercing", "1", "When set to 1, backstabs use armor piercing upgrades to determine the damage.");
 	
 	// Always keep this hook active
 	sm_mvm_enabled.AddChangeHook(ConVarChanged_Enabled);

--- a/addons/sourcemod/scripting/mannvsmann/helpers.sp
+++ b/addons/sourcemod/scripting/mannvsmann/helpers.sp
@@ -285,3 +285,8 @@ bool IsPlayerDefender(int client)
 {
 	return (GetDefenderTeam() == TFTeam_Any || TF2_GetClientTeam(client) == GetDefenderTeam());
 }
+
+bool IsWeaponBaseMelee(int entity)
+{
+	return HasEntProp(entity, Prop_Data, "CTFWeaponBaseMeleeSmack");
+}


### PR DESCRIPTION
Implements the `armor piercing` attribute.

Adds the `sm_mvm_backstab_armor_piercing` convar to allow toggling the old behavior.