### PR TITLE
Rework stun mechanics from upgrades

### DIFF
--- a/addons/sourcemod/gamedata/mannvsmann.txt
+++ b/addons/sourcemod/gamedata/mannvsmann.txt
@@ -144,6 +144,21 @@
 				"linux"		"@_ZN16CTFPowerupBottle12AllowedToUseEv"
 				"windows"	"\xA1\x2A\x2A\x2A\x2A\x57\x8B\xF9\x85\xC0\x74\x2A\x8B\x80\x88\x03\x00\x00"
 			}
+			"CTFKnife::CanPerformBackstabAgainstTarget"
+			{
+				"linux"		"@_ZN8CTFKnife31CanPerformBackstabAgainstTargetEP9CTFPlayer"
+				"windows"	"\x55\x8B\xEC\x51\x56\x8B\x75\x08\x57\x8B\xF9\x85\xF6\x75\x2A\x5F"
+			}
+			"CTFBaseRocket::CheckForStunOnImpact"
+			{
+				"linux"		"@_ZN13CTFBaseRocket20CheckForStunOnImpactEP9CTFPlayer"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x30\x53\x56\x8B\xF1\x57\x80\xBE\x01\x05\x00\x00\x00"
+			}
+			"CTFSniperRifle::ExplosiveHeadShot"
+			{
+				"linux"		"@_ZN14CTFSniperRifle17ExplosiveHeadShotEP9CTFPlayerS1_"
+				"windows"	"\x55\x8B\xEC\x81\xEC\xEC\x00\x00\x00\x53\x8B\x5D\x08"
+			}
 			"UTIL_RemoveImmediate"
 			{
 				"linux"		"@_Z20UTIL_RemoveImmediateP11CBaseEntity"
@@ -171,6 +186,11 @@
 			{
 				"linux"		"481"
 				"windows"	"474"
+			}
+			"CTFStunBall::ApplyBallImpactEffectOnVictim"
+			{
+				"linux"		"267"
+				"windows"	"266"
 			}
 			"CTFGameRules::SetWinningTeam"
 			{
@@ -421,6 +441,52 @@
 				"return"	"bool"
 				"this"		"entity"
 			}
+			"CTFKnife::CanPerformBackstabAgainstTarget"
+			{
+				"signature"	"CTFKnife::CanPerformBackstabAgainstTarget"
+				"callconv"	"thiscall"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"pTarget"
+					{
+						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CTFBaseRocket::CheckForStunOnImpact"
+			{
+				"signature"	"CTFBaseRocket::CheckForStunOnImpact"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pTarget"
+					{
+						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CTFSniperRifle::ExplosiveHeadShot"
+			{
+				"signature"	"CTFSniperRifle::ExplosiveHeadShot"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pAttacker"
+					{
+						"type"	"cbaseentity"
+					}
+					"pVictim"
+					{
+						"type"	"cbaseentity"
+					}
+				}
+			}
 			"CCurrencyPack::MyTouch"
 			{
 				"offset"	"CCurrencyPack::MyTouch"
@@ -475,6 +541,20 @@
 					"piCustomDamage"
 					{
 						"type"	"int"
+					}
+				}
+			}
+			"CTFStunBall::ApplyBallImpactEffectOnVictim"
+			{
+				"offset"	"CTFStunBall::ApplyBallImpactEffectOnVictim"
+				"hooktype"	"entity"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pOther"
+					{
+						"type"	"cbaseentity"
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -150,19 +150,6 @@ enum
 	NUM_OBSERVER_MODES,
 };
 
-// edict->solid values
-enum SolidType_t
-{
-	SOLID_NONE			= 0,	// no solid model
-	SOLID_BSP			= 1,	// a BSP tree
-	SOLID_BBOX			= 2,	// an AABB
-	SOLID_OBB			= 3,	// an OBB (not implemented yet)
-	SOLID_OBB_YAW		= 4,	// an OBB, constrained so that it can only yaw
-	SOLID_CUSTOM		= 5,	// Always call into the entity for tests
-	SOLID_VPHYSICS		= 6,	// solid vphysics object, get vcollide from the model and collide with that
-	SOLID_LAST,
-};
-
 enum
 {
 	RESET_MODE_TEAM_SWITCH = 0,
@@ -589,13 +576,9 @@ void SetupOnMapStart()
 		MvMTeam(team).Reset();
 	}
 	
-	// Some upgrades require a valid populator
+	// Create a populator and an upgrade station, which enable some MvM features
 	CreateEntityByName("info_populator");
-	
-	// Set solid type to SOLID_NONE to suppress warnings
-	int upgradestation = CreateEntityByName("func_upgradestation");
-	SetEntProp(upgradestation, Prop_Send, "m_nSolidType", SOLID_NONE);
-	DispatchSpawn(upgradestation);
+	DispatchSpawn(CreateEntityByName("func_upgradestation"));
 }
 
 void TogglePlugin(bool enable)

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -202,6 +202,7 @@ ConVar sm_mvm_upgrades_reset_mode;
 ConVar sm_mvm_showhealth;
 ConVar sm_mvm_spawn_protection;
 ConVar sm_mvm_music_enabled;
+ConVar sm_mvm_players_are_minibosses;
 ConVar sm_mvm_gas_explode_damage_modifier;
 ConVar sm_mvm_explosive_sniper_shot_damage_modifier;
 ConVar sm_mvm_medigun_shield_damage_modifier;

--- a/addons/sourcemod/scripting/mannvsmann.sp
+++ b/addons/sourcemod/scripting/mannvsmann.sp
@@ -27,7 +27,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.13.0"
+#define PLUGIN_VERSION	"1.14.0"
 
 #define DEFAULT_UPGRADES_FILE	"scripts/items/mvm_upgrades.txt"
 

--- a/addons/sourcemod/scripting/mannvsmann/convars.sp
+++ b/addons/sourcemod/scripting/mannvsmann/convars.sp
@@ -35,6 +35,7 @@ void ConVars_Init()
 	sm_mvm_showhealth = CreateConVar("sm_mvm_showhealth", "0", "When set to 1, shows a floating health icon over enemy players.");
 	sm_mvm_spawn_protection = CreateConVar("sm_mvm_spawn_protection", "1", "When set to 1, players are granted ubercharge while they leave their spawn.");
 	sm_mvm_music_enabled = CreateConVar("sm_mvm_music_enabled", "1", "When set to 1, Mann vs. Machine music will play at the start and end of a round.");
+	sm_mvm_players_are_minibosses = CreateConVar("sm_mvm_players_are_minibosses", "1", "When set to 1, all upgrades will function as if players are MvM giants.");
 	sm_mvm_gas_explode_damage_modifier = CreateConVar("sm_mvm_gas_explode_damage_modifier", "0.5", "Multiplier to damage of the explosion created by the 'Explode On Ignite' upgrade.");
 	sm_mvm_explosive_sniper_shot_damage_modifier = CreateConVar("sm_mvm_explosive_sniper_shot_damage_modifier", "1.0", "Multiplier to damage of the explosion created by the 'Explosive Headshot' upgrade.");
 	sm_mvm_medigun_shield_damage_modifier = CreateConVar("sm_mvm_medigun_shield_damage_modifier", "0", "Multiplier to damage of the shield created by the Medi Gun's 'Projectile Shield' upgrade.");

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -668,14 +668,15 @@ static MRESReturn DHookCallback_AllowedToUse_Post(int bottle, DHookReturn ret)
 
 static MRESReturn DHookCallback_CanPerformBackstabAgainstTarget_Pre(int knife, DHookReturn ret, DHookParam params)
 {
+	int target = params.Get(1);
+	
 	SetMannVsMachineMode(true);
+	
+	MvMPlayer(target).SetTeam(TFTeam_Blue);
 	
 	if (sm_mvm_players_are_minibosses.BoolValue)
 	{
-		int target = params.Get(1);
-		
 		// Minibosses cannot be backstabbed from all sides while sapped
-		MvMPlayer(target).SetTeam(TFTeam_Blue);
 		MvMPlayer(target).SetIsMiniBoss(true);
 	}
 	
@@ -684,13 +685,14 @@ static MRESReturn DHookCallback_CanPerformBackstabAgainstTarget_Pre(int knife, D
 
 static MRESReturn DHookCallback_CanPerformBackstabAgainstTarget_Post(int knife, DHookReturn ret, DHookParam params)
 {
+	int target = params.Get(1);
+	
 	ResetMannVsMachineMode();
+	
+	MvMPlayer(target).ResetTeam();
 	
 	if (sm_mvm_players_are_minibosses.BoolValue)
 	{
-		int target = params.Get(1);
-		
-		MvMPlayer(target).ResetTeam();
 		MvMPlayer(target).ResetIsMiniBoss();
 	}
 	

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -455,10 +455,10 @@ static MRESReturn DHookCallback_RadiusSpyScan_Pre(Address pShared)
 
 static MRESReturn DHookCallback_RadiusSpyScan_Post(Address pShared)
 {
-	int player = TF2Util_GetPlayerFromSharedAddress(pShared);
-	
 	if (!sm_mvm_radius_spy_scan.BoolValue)
 	{
+		int player = TF2Util_GetPlayerFromSharedAddress(pShared);
+		
 		MvMPlayer(player).ResetTeam();
 		return MRES_Ignored;
 	}
@@ -549,7 +549,7 @@ static MRESReturn DHookCallback_FindSnapToBuildPos_Pre(int obj, DHookReturn ret,
 		// The robot sapper only works on bots, give every player the fake client flag
 		for (int client = 1; client <= MaxClients; client++)
 		{
-			if (IsClientInGame(client) && client != builder)
+			if (client != builder && IsClientInGame(client))
 			{
 				MvMPlayer(client).AddFlags(FL_FAKECLIENT);
 			}
@@ -569,7 +569,7 @@ static MRESReturn DHookCallback_FindSnapToBuildPos_Post(int obj, DHookReturn ret
 		
 		for (int client = 1; client <= MaxClients; client++)
 		{
-			if (IsClientInGame(client) && client != builder)
+			if (client != builder && IsClientInGame(client))
 			{
 				MvMPlayer(client).ResetFlags();
 			}
@@ -726,7 +726,7 @@ static MRESReturn DHookCallback_ExplosiveHeadShot_Pre(int sniperrifle, DHookPara
 		
 		for (int client = 1; client <= MaxClients; client++)
 		{
-			if (IsClientInGame(client) && client != attacker)
+			if (client != attacker && IsClientInGame(client))
 			{
 				// Minibosses receive a weaker explosive headshot stun
 				MvMPlayer(client).SetIsMiniBoss(true);
@@ -745,7 +745,7 @@ static MRESReturn DHookCallback_ExplosiveHeadShot_Post(int sniperrifle, DHookPar
 		
 		for (int client = 1; client <= MaxClients; client++)
 		{
-			if (IsClientInGame(client) && client != attacker)
+			if (client != attacker && IsClientInGame(client))
 			{
 				MvMPlayer(client).ResetIsMiniBoss();
 			}
@@ -857,6 +857,7 @@ static MRESReturn DHookCallback_ApplyBallImpactEffectOnVictim_Pre(int ball, DHoo
 	{
 		int player = params.Get(1);
 		
+		// Minibosses cannot get fully stunned by sandman balls
 		MvMPlayer(player).SetIsMiniBoss(true);
 	}
 	

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -478,10 +478,12 @@ static MRESReturn DHookCallback_ApplyRocketPackStun_Pre(Address pShared, DHookPa
 {
 	if (sm_mvm_players_are_minibosses.BoolValue)
 	{
+		int player = TF2Util_GetPlayerFromSharedAddress(pShared);
+		
 		// Minibosses get slowed down instead of fully stunned
 		for (int client = 1; client <= MaxClients; client++)
 		{
-			if (IsClientInGame(client))
+			if (client != player && IsClientInGame(client))
 			{
 				MvMPlayer(client).SetIsMiniBoss(true);
 			}
@@ -495,9 +497,11 @@ static MRESReturn DHookCallback_ApplyRocketPackStun_Post(Address pShared, DHookP
 {
 	if (sm_mvm_players_are_minibosses.BoolValue)
 	{
+		int player = TF2Util_GetPlayerFromSharedAddress(pShared);
+		
 		for (int client = 1; client <= MaxClients; client++)
 		{
-			if (IsClientInGame(client))
+			if (client != player && IsClientInGame(client))
 			{
 				MvMPlayer(client).ResetIsMiniBoss();
 			}


### PR DESCRIPTION
Certain upgrades in MvM are much weaker against giant robots e.g. the sapper only slows giants instead of fully stunning them. Mann vs. Mann partially mirrored this behavior against players, but not everything was considered.

This PR applies these nerfs to the "Rocket Specialist" and "Explosive Headshot" upgrades, as well as adding a new convar `sm_mvm_players_are_minibosses` to toggle this behavior for **all** upgrades.