### PR TITLE
Replace inlined detours for 2024-04-18 TF2 update

### DIFF
--- a/addons/sourcemod/gamedata/mannvsmann.txt
+++ b/addons/sourcemod/gamedata/mannvsmann.txt
@@ -164,7 +164,7 @@
 				"windows"	"\x55\x8B\xEC\x83\xEC\x20\x53\x56\x8B\x75\x08\x8B\xD9\x57\x6A\x01"
 			}
 			// "player_used_powerup_bottle"
-			"CTFPowerupBottle::AllowedToUse"
+			"CTFPowerupBottle::Use"
 			{
 				"linux"		"@_ZN16CTFPowerupBottle3UseEv"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x1C\x56\x57\x8B\xF9\x80\xBF\xE8\x05\x00\x00\x00"

--- a/addons/sourcemod/gamedata/mannvsmann.txt
+++ b/addons/sourcemod/gamedata/mannvsmann.txt
@@ -151,10 +151,11 @@
 				"linux"		"@_ZN11CBaseObject16ShouldQuickBuildEv"
 				"windows"	"\x83\x3D\x2A\x2A\x2A\x2A\x00\x56\x8B\xF1\x74\x2A\x8B\x06"
 			}
-			"CObjectSapper::ApplyRoboSapperEffects"
+			// "Explosion_ShockWave_01" -> the largest function
+			"CObjectSapper::ApplyRoboSapper"
 			{
-				"linux"		"@_ZN13CObjectSapper22ApplyRoboSapperEffectsEP9CTFPlayerf"
-				// FIXME: This is inlined on Windows
+				"linux"		"@_ZN13CObjectSapper15ApplyRoboSapperEP9CTFPlayerfi"
+				"windows"	"\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x04\x89\x6C\x24\x04\x8B\xEC\x81\xEC\x08\x01\x00\x00\x56\x57\x8B\x7B\x08\x8B\xF1\x57"
 			}
 			// "Regenerate.Touch" -> the function with "SetAnimation", "open" and "close"
 			"CRegenerateZone::Regenerate"
@@ -162,11 +163,11 @@
 				"linux"		"@_ZN15CRegenerateZone10RegenerateEP9CTFPlayer"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x20\x53\x56\x8B\x75\x08\x8B\xD9\x57\x6A\x01"
 			}
-			// TODO: THIS IS INLINED ON WINDOWS
+			// "player_used_powerup_bottle"
 			"CTFPowerupBottle::AllowedToUse"
 			{
-				"linux"		"@_ZN16CTFPowerupBottle12AllowedToUseEv"
-				// FIXME: This is inlined on Windows
+				"linux"		"@_ZN16CTFPowerupBottle3UseEv"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x1C\x56\x57\x8B\xF9\x80\xBF\xE8\x05\x00\x00\x00"
 			}
 			// "cannot_be_backstabbed"
 			"CTFKnife::CanPerformBackstabAgainstTarget"
@@ -449,9 +450,9 @@
 				"return"	"bool"
 				"this"		"entity"
 			}
-			"CObjectSapper::ApplyRoboSapperEffects"
+			"CObjectSapper::ApplyRoboSapper"
 			{
-				"signature"	"CObjectSapper::ApplyRoboSapperEffects"
+				"signature"	"CObjectSapper::ApplyRoboSapper"
 				"callconv"	"thiscall"
 				"return"	"bool"
 				"this"		"entity"
@@ -464,6 +465,10 @@
 					"flDuration"
 					{
 						"type"	"float"
+					}
+					"iRadius"
+					{
+						"type"	"int"
 					}
 				}
 			}
@@ -481,9 +486,9 @@
 					}
 				}
 			}
-			"CTFPowerupBottle::AllowedToUse"
+			"CTFPowerupBottle::Use"
 			{
-				"signature"	"CTFPowerupBottle::AllowedToUse"
+				"signature"	"CTFPowerupBottle::Use"
 				"callconv"	"thiscall"
 				"return"	"bool"
 				"this"		"entity"

--- a/addons/sourcemod/scripting/mannvsmann/dhooks.sp
+++ b/addons/sourcemod/scripting/mannvsmann/dhooks.sp
@@ -65,9 +65,9 @@ void DHooks_Init(GameData gamedata)
 	DHooks_AddDynamicDetour(gamedata, "CTFPlayer::RemoveAllOwnedEntitiesFromWorld", DHookCallback_CTFPlayer_RemoveAllOwnedEntitiesFromWorld_Pre, DHookCallback_CTFPlayer_RemoveAllOwnedEntitiesFromWorld_Post);
 	DHooks_AddDynamicDetour(gamedata, "CBaseObject::FindSnapToBuildPos", DHookCallback_CBaseObject_FindSnapToBuildPos_Pre, DHookCallback_CBaseObject_FindSnapToBuildPos_Post);
 	DHooks_AddDynamicDetour(gamedata, "CBaseObject::ShouldQuickBuild", DHookCallback_CBaseObject_ShouldQuickBuild_Pre, DHookCallback_CBaseObject_ShouldQuickBuild_Post);
-	DHooks_AddDynamicDetour(gamedata, "CObjectSapper::ApplyRoboSapperEffects", DHookCallback_CObjectSapper_ApplyRoboSapperEffects_Pre, DHookCallback_CObjectSapper_ApplyRoboSapperEffects_Post);
+	DHooks_AddDynamicDetour(gamedata, "CObjectSapper::ApplyRoboSapper", DHookCallback_CObjectSapper_ApplyRoboSapper_Pre, DHookCallback_CObjectSapper_ApplyRoboSapper_Post);
 	DHooks_AddDynamicDetour(gamedata, "CRegenerateZone::Regenerate", DHookCallback_CRegenerateZone_Regenerate_Pre);
-	DHooks_AddDynamicDetour(gamedata, "CTFPowerupBottle::AllowedToUse", DHookCallback_CTFPowerupBottle_AllowedToUse_Pre, DHookCallback_CTFPowerupBottle_AllowedToUse_Post);
+	DHooks_AddDynamicDetour(gamedata, "CTFPowerupBottle::Use", DHookCallback_CTFPowerupBottle_Use_Pre, DHookCallback_CTFPowerupBottle_Use_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFKnife::CanPerformBackstabAgainstTarget", DHookCallback_CTFKnife_CanPerformBackstabAgainstTarget_Pre, DHookCallback_CTFKnife_CanPerformBackstabAgainstTarget_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFBaseRocket::CheckForStunOnImpact", DHookCallback_CTFBaseRocket_CheckForStunOnImpact_Pre, DHookCallback_CTFBaseRocket_CheckForStunOnImpact_Post);
 	DHooks_AddDynamicDetour(gamedata, "CTFSniperRifle::ExplosiveHeadShot", DHookCallback_CTFSniperRifle_ExplosiveHeadShot_Pre, DHookCallback_CTFSniperRifle_ExplosiveHeadShot_Post);
@@ -628,26 +628,34 @@ static MRESReturn DHookCallback_CBaseObject_ShouldQuickBuild_Post(int obj, DHook
 	return MRES_Ignored;
 }
 
-static MRESReturn DHookCallback_CObjectSapper_ApplyRoboSapperEffects_Pre(int sapper, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_CObjectSapper_ApplyRoboSapper_Pre(int sapper, DHookReturn ret, DHookParam params)
 {
 	if (sm_mvm_players_are_minibosses.BoolValue)
 	{
-		int target = params.Get(1);
-		
 		// Minibosses get slowed down instead of fully stunned
-		MvMPlayer(target).SetIsMiniBoss(true);
+		for (int client = 1; client <= MaxClients; client++)
+		{
+			if (IsClientInGame(client))
+			{
+				MvMPlayer(client).SetIsMiniBoss(true);
+			}
+		}
 	}
 	
 	return MRES_Ignored;
 }
 
-static MRESReturn DHookCallback_CObjectSapper_ApplyRoboSapperEffects_Post(int sapper, DHookReturn ret, DHookParam params)
+static MRESReturn DHookCallback_CObjectSapper_ApplyRoboSapper_Post(int sapper, DHookReturn ret, DHookParam params)
 {
 	if (sm_mvm_players_are_minibosses.BoolValue)
 	{
-		int target = params.Get(1);
-		
-		MvMPlayer(target).ResetIsMiniBoss();
+		for (int client = 1; client <= MaxClients; client++)
+		{
+			if (IsClientInGame(client))
+			{
+				MvMPlayer(client).ResetIsMiniBoss();
+			}
+		}
 	}
 	
 	return MRES_Ignored;
@@ -672,7 +680,7 @@ static MRESReturn DHookCallback_CRegenerateZone_Regenerate_Pre(int regenerate, D
 	return MRES_Ignored;
 }
 
-static MRESReturn DHookCallback_CTFPowerupBottle_AllowedToUse_Pre(int bottle, DHookReturn ret)
+static MRESReturn DHookCallback_CTFPowerupBottle_Use_Pre(int bottle, DHookReturn ret)
 {
 	if (IsInArenaMode() && sm_mvm_arena_canteens.BoolValue && GameRules_GetRoundState() == RoundState_Stalemate)
 	{
@@ -684,7 +692,7 @@ static MRESReturn DHookCallback_CTFPowerupBottle_AllowedToUse_Pre(int bottle, DH
 	return MRES_Ignored;
 }
 
-static MRESReturn DHookCallback_CTFPowerupBottle_AllowedToUse_Post(int bottle, DHookReturn ret)
+static MRESReturn DHookCallback_CTFPowerupBottle_Use_Post(int bottle, DHookReturn ret)
 {
 	if (IsInArenaMode() && sm_mvm_arena_canteens.BoolValue && GameRules_GetRoundState() == RoundState_RoundRunning)
 	{


### PR DESCRIPTION
**Untested**, ApplyRoboSapper has a clone on linux and may need to be changed.

Replaces `CObjectSapper::ApplyRoboSapperEffects` with `CObjectSapper::ApplyRoboSapper` as the former function is now inlined on Windows. Will instead apply mini-boss flag to all players while `ApplyRoboSapper` is in progress.

Replaces `CTFPowerupBottle::AllowedToUse` with `CTFPowerupBottle::Use` as the former function is now inlined on Windows.